### PR TITLE
Handle monolithic HP ops during incremental updates

### DIFF
--- a/src/kernel/services/compute_service.cpp
+++ b/src/kernel/services/compute_service.cpp
@@ -1295,18 +1295,8 @@ NodeOutput& ComputeService::compute_high_precision_update(
         }
       }
     } else if (hp_mono_fn) {
-      bool needs_compute = true;
-      if (node.cached_output_high_precision) {
-        const auto& existing = node.cached_output_high_precision->image_buffer;
-        needs_compute = (existing.width != entry.hp_size.width ||
-                         existing.height != entry.hp_size.height ||
-                         !existing.data);
-      }
-
-      if (needs_compute) {
-        node.cached_output_high_precision =
-            (*hp_mono_fn)(node, image_inputs_ready);
-      }
+      node.cached_output_high_precision =
+          (*hp_mono_fn)(node, image_inputs_ready);
 
       if (!node.cached_output_high_precision) {
         throw GraphError(GraphErrc::ComputeError,

--- a/src/kernel/services/compute_service.cpp
+++ b/src/kernel/services/compute_service.cpp
@@ -1179,121 +1179,144 @@ NodeOutput& ComputeService::compute_high_precision_update(
       image_inputs_ready.push_back(parent_out);
     }
 
-    // Ensure output HP buffer exists and is correctly sized
-    auto [channels, dtype] = [&]() -> std::pair<int, DataType> {
-      if (node.cached_output_high_precision) {
-        const auto& b = node.cached_output_high_precision->image_buffer;
-        if (b.width > 0)
-          return {b.channels, b.type};
-      }
-      for (const auto* in : image_inputs_ready) {
-        const auto& b = in->image_buffer;
-        if (b.width > 0)
-          return {b.channels, b.type};
-      }
-      return {1, DataType::FLOAT32};
-    }();
-    if (!node.cached_output_high_precision)
-      node.cached_output_high_precision = NodeOutput{};
-    ImageBuffer& hp_buffer = node.cached_output_high_precision->image_buffer;
-    if (hp_buffer.width != entry.hp_size.width ||
-        hp_buffer.height != entry.hp_size.height ||
-        hp_buffer.channels != channels || hp_buffer.type != dtype ||
-        !hp_buffer.data) {
-      hp_buffer.width = entry.hp_size.width;
-      hp_buffer.height = entry.hp_size.height;
-      hp_buffer.channels = channels;
-      hp_buffer.type = dtype;
-      hp_buffer.device = Device::CPU;
-      size_t row_bytes =
-          static_cast<size_t>(hp_buffer.width) * channels * sizeof(float);
-      hp_buffer.step = row_bytes;
-      hp_buffer.data.reset(new char[row_bytes * hp_buffer.height],
-                           std::default_delete<char[]>());
-      std::memset(hp_buffer.data.get(), 0, row_bytes * hp_buffer.height);
-    }
-
-    // Get tiled operator
     const auto* impls =
         OpRegistry::instance().get_implementations(node.type, node.subtype);
     const TileOpFunc* hp_tile_fn =
         (impls && impls->tiled_hp) ? &*impls->tiled_hp : nullptr;
-    if (!hp_tile_fn)
-      throw GraphError(
-          GraphErrc::NoOperation,
-          "No tiled HP operator for " + node.type + ":" + node.subtype);
+    const MonolithicOpFunc* hp_mono_fn =
+        (impls && impls->monolithic_hp) ? &*impls->monolithic_hp : nullptr;
 
-    // Execute tiling logic
-    TileTask task;
-    task.node = &node;
-    task.output_tile.buffer = &hp_buffer;
-    const cv::Size out_bounds(hp_buffer.width, hp_buffer.height);
-
-    // Prioritize Macro tiles
-    cv::Rect macro_cover = align_rect(entry.roi_hp, kHpMacroTileSize);
-    macro_cover = clip_rect(macro_cover, out_bounds);
-    for (int y = macro_cover.y; y < macro_cover.y + macro_cover.height;
-         y += kHpMacroTileSize) {
-      for (int x = macro_cover.x; x < macro_cover.x + macro_cover.width;
-           x += kHpMacroTileSize) {
-        cv::Rect macro_tile(
-            x, y,
-            std::min(kHpMacroTileSize, macro_cover.x + macro_cover.width - x),
-            std::min(kHpMacroTileSize, macro_cover.y + macro_cover.height - y));
-        macro_tile = clip_rect(macro_tile, out_bounds);
-        if (is_rect_empty(macro_tile))
-          continue;
-        cv::Rect touched = macro_tile & entry.roi_hp;
-        if (is_rect_empty(touched))
-          continue;
-
-        // If ROI covers the entire macro tile, process it as one big tile
-        if (touched == macro_tile && macro_tile.width >= kHpMacroTileSize &&
-            macro_tile.height >= kHpMacroTileSize) {
-          task.output_tile.roi = macro_tile;
-          task.input_tiles.clear();
-          for (const auto* in_out : image_inputs_ready) {
-            Tile in_tile;
-            in_tile.buffer = const_cast<ImageBuffer*>(&in_out->image_buffer);
-            in_tile.roi = clip_rect(expand_rect(macro_tile, entry.halo_hp),
-                                    cv::Size(in_out->image_buffer.width,
-                                             in_out->image_buffer.height));
-            task.input_tiles.push_back(in_tile);
-          }
-          execute_tile_task(task, *hp_tile_fn);
-          continue;
+    if (hp_tile_fn) {
+      // Ensure output HP buffer exists and is correctly sized
+      auto [channels, dtype] = [&]() -> std::pair<int, DataType> {
+        if (node.cached_output_high_precision) {
+          const auto& b = node.cached_output_high_precision->image_buffer;
+          if (b.width > 0)
+            return {b.channels, b.type};
         }
+        for (const auto* in : image_inputs_ready) {
+          const auto& b = in->image_buffer;
+          if (b.width > 0)
+            return {b.channels, b.type};
+        }
+        return {1, DataType::FLOAT32};
+      }();
 
-        // Otherwise, fall back to micro tiles for the intersected region
-        cv::Rect micro_cover = align_rect(touched, kHpMicroTileSize);
-        micro_cover = clip_rect(micro_cover, out_bounds) & macro_tile;
-        for (int my = micro_cover.y; my < micro_cover.y + micro_cover.height;
-             my += kHpMicroTileSize) {
-          for (int mx = micro_cover.x; mx < micro_cover.x + micro_cover.width;
-               mx += kHpMicroTileSize) {
-            cv::Rect micro_tile(
-                mx, my,
-                std::min(kHpMicroTileSize,
-                         micro_cover.x + micro_cover.width - mx),
-                std::min(kHpMicroTileSize,
-                         micro_cover.y + micro_cover.height - my));
-            micro_tile = clip_rect(micro_tile, out_bounds);
-            if (is_rect_empty(micro_tile))
-              continue;
-            task.output_tile.roi = micro_tile;
+      if (!node.cached_output_high_precision)
+        node.cached_output_high_precision = NodeOutput{};
+      ImageBuffer& hp_buffer = node.cached_output_high_precision->image_buffer;
+      if (hp_buffer.width != entry.hp_size.width ||
+          hp_buffer.height != entry.hp_size.height ||
+          hp_buffer.channels != channels || hp_buffer.type != dtype ||
+          !hp_buffer.data) {
+        hp_buffer.width = entry.hp_size.width;
+        hp_buffer.height = entry.hp_size.height;
+        hp_buffer.channels = channels;
+        hp_buffer.type = dtype;
+        hp_buffer.device = Device::CPU;
+        size_t row_bytes =
+            static_cast<size_t>(hp_buffer.width) * channels * sizeof(float);
+        hp_buffer.step = row_bytes;
+        hp_buffer.data.reset(new char[row_bytes * hp_buffer.height],
+                             std::default_delete<char[]>());
+        std::memset(hp_buffer.data.get(), 0, row_bytes * hp_buffer.height);
+      }
+
+      // Execute tiling logic
+      TileTask task;
+      task.node = &node;
+      task.output_tile.buffer = &hp_buffer;
+      const cv::Size out_bounds(hp_buffer.width, hp_buffer.height);
+
+      // Prioritize Macro tiles
+      cv::Rect macro_cover = align_rect(entry.roi_hp, kHpMacroTileSize);
+      macro_cover = clip_rect(macro_cover, out_bounds);
+      for (int y = macro_cover.y; y < macro_cover.y + macro_cover.height;
+           y += kHpMacroTileSize) {
+        for (int x = macro_cover.x; x < macro_cover.x + macro_cover.width;
+             x += kHpMacroTileSize) {
+          cv::Rect macro_tile(
+              x, y,
+              std::min(kHpMacroTileSize, macro_cover.x + macro_cover.width - x),
+              std::min(kHpMacroTileSize, macro_cover.y + macro_cover.height - y));
+          macro_tile = clip_rect(macro_tile, out_bounds);
+          if (is_rect_empty(macro_tile))
+            continue;
+          cv::Rect touched = macro_tile & entry.roi_hp;
+          if (is_rect_empty(touched))
+            continue;
+
+          // If ROI covers the entire macro tile, process it as one big tile
+          if (touched == macro_tile && macro_tile.width >= kHpMacroTileSize &&
+              macro_tile.height >= kHpMacroTileSize) {
+            task.output_tile.roi = macro_tile;
             task.input_tiles.clear();
             for (const auto* in_out : image_inputs_ready) {
               Tile in_tile;
               in_tile.buffer = const_cast<ImageBuffer*>(&in_out->image_buffer);
-              in_tile.roi = clip_rect(expand_rect(micro_tile, entry.halo_hp),
+              in_tile.roi = clip_rect(expand_rect(macro_tile, entry.halo_hp),
                                       cv::Size(in_out->image_buffer.width,
                                                in_out->image_buffer.height));
               task.input_tiles.push_back(in_tile);
             }
             execute_tile_task(task, *hp_tile_fn);
+            continue;
+          }
+
+          // Otherwise, fall back to micro tiles for the intersected region
+          cv::Rect micro_cover = align_rect(touched, kHpMicroTileSize);
+          micro_cover = clip_rect(micro_cover, out_bounds) & macro_tile;
+          for (int my = micro_cover.y; my < micro_cover.y + micro_cover.height;
+               my += kHpMicroTileSize) {
+            for (int mx = micro_cover.x; mx < micro_cover.x + micro_cover.width;
+                 mx += kHpMicroTileSize) {
+              cv::Rect micro_tile(
+                  mx, my,
+                  std::min(kHpMicroTileSize,
+                           micro_cover.x + micro_cover.width - mx),
+                  std::min(kHpMicroTileSize,
+                           micro_cover.y + micro_cover.height - my));
+              micro_tile = clip_rect(micro_tile, out_bounds);
+              if (is_rect_empty(micro_tile))
+                continue;
+              task.output_tile.roi = micro_tile;
+              task.input_tiles.clear();
+              for (const auto* in_out : image_inputs_ready) {
+                Tile in_tile;
+                in_tile.buffer = const_cast<ImageBuffer*>(&in_out->image_buffer);
+                in_tile.roi = clip_rect(expand_rect(micro_tile, entry.halo_hp),
+                                        cv::Size(in_out->image_buffer.width,
+                                                 in_out->image_buffer.height));
+                task.input_tiles.push_back(in_tile);
+              }
+              execute_tile_task(task, *hp_tile_fn);
+            }
           }
         }
       }
+    } else if (hp_mono_fn) {
+      bool needs_compute = true;
+      if (node.cached_output_high_precision) {
+        const auto& existing = node.cached_output_high_precision->image_buffer;
+        needs_compute = (existing.width != entry.hp_size.width ||
+                         existing.height != entry.hp_size.height ||
+                         !existing.data);
+      }
+
+      if (needs_compute) {
+        node.cached_output_high_precision =
+            (*hp_mono_fn)(node, image_inputs_ready);
+      }
+
+      if (!node.cached_output_high_precision) {
+        throw GraphError(GraphErrc::ComputeError,
+                         "Monolithic HP operator produced no output for " +
+                             node.type + ":" + node.subtype);
+      }
+    } else {
+      throw GraphError(GraphErrc::NoOperation,
+                       "No suitable HP operator (tiled or monolithic) for " +
+                           node.type + ":" + node.subtype);
     }
 
     // Update node state

--- a/util/testcases/dirty_region_test.yaml
+++ b/util/testcases/dirty_region_test.yaml
@@ -11,7 +11,7 @@
 - id: 2
   name: Heavy_Blur
   type: image_process
-  subtype: gaussian_blur_tiled # 这个操作有 tiled_op 实现
+  subtype: micro_blur_for_test 
   image_inputs:
     - from_node_id: 1
   parameters:


### PR DESCRIPTION
## Summary
- allow high precision incremental updates to fall back to monolithic operators when tiled implementations are unavailable
- retain existing tiling flow for operators that support it while reusing cached buffers when sizes match
- raise clearer errors if neither tiled nor monolithic high precision implementations exist

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: missing OpenCV package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f1fc1734488320a37e59f7768e8433