### PR TITLE
Define compute_upstream_roi implementation

### DIFF
--- a/src/kernel/services/graph_traversal_service.cpp
+++ b/src/kernel/services/graph_traversal_service.cpp
@@ -634,6 +634,12 @@ cv::Rect compute_upstream_roi_impl(
   return has_roi ? upstream_roi : cv::Rect();
 }
 
+cv::Rect GraphTraversalService::compute_upstream_roi(
+    const Node& node, const cv::Rect& downstream_roi, const GraphModel& graph,
+    std::unordered_map<int, cv::Size>& size_cache) {
+  return compute_upstream_roi_impl(node, downstream_roi, graph, size_cache);
+}
+
 }  // namespace ps
 
 std::optional<cv::Rect> ps::GraphTraversalService::project_roi_forward(


### PR DESCRIPTION
## Summary
- add the missing GraphTraversalService::compute_upstream_roi definition
- forward to the existing compute_upstream_roi_impl helper

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954bfff2f0c8320afa16d5f663996fe)