### PR TITLE
[fix] align HP device selection

### DIFF
--- a/include/kernel/scheduler/gpu_pipeline_scheduler.hpp
+++ b/include/kernel/scheduler/gpu_pipeline_scheduler.hpp
@@ -38,10 +38,7 @@ class GpuPipelineScheduler : public IScheduler, public SchedulerTaskRuntime {
     // 是否优先使用 GPU（HP 模式）
     bool prefer_gpu_for_hp;
 
-    Config()
-        : gpu_workers(1),
-          cpu_workers(0),
-          prefer_gpu_for_hp(true) {}
+    Config() : gpu_workers(1), cpu_workers(0), prefer_gpu_for_hp(true) {}
   };
 
   /// @brief 构造函数
@@ -169,16 +166,26 @@ class GpuPipelineScheduler : public IScheduler, public SchedulerTaskRuntime {
   /// @brief 检查 GPU 是否可用
   bool is_gpu_available() const;
 
-  /// @brief 获取当前可用设备列表
+  /**
+   * @brief Returns devices that HP production compute may target here.
+   *
+   * @return CPU plus GPU_METAL only when a Metal device is attached and HP GPU
+   * dispatch is enabled by config and worker availability.
+   * @throws std::bad_alloc if vector allocation fails.
+   * @note This list feeds TaskSubmissionPlan operation resolution. It must
+   * remain aligned with can_dispatch_hp_to_gpu() so disabled GPU workers or
+   * CPU-for-HP configurations do not select GPU implementations for CPU queues.
+   */
   std::vector<Device> get_available_devices() const;
 
   /**
    * @brief Reports devices available to compute tasks submitted here.
    *
-   * @return CPU plus GPU_METAL when this runtime has an attached Metal device.
+   * @return Same list as get_available_devices().
    * @throws std::bad_alloc if vector allocation fails.
    * @note This overrides SchedulerTaskRuntime so production operation
-   * resolution can choose registered per-device implementations.
+   * resolution can choose registered per-device implementations only for
+   * devices this scheduler is currently willing to dispatch.
    */
   std::vector<Device> available_devices() const override;
 
@@ -287,7 +294,6 @@ class GpuPipelineScheduler : public IScheduler, public SchedulerTaskRuntime {
   static thread_local int tls_worker_id_;
   static thread_local uint64_t tls_active_epoch_;
   static thread_local bool tls_is_gpu_worker_;
-
 };
 
 }  // namespace ps

--- a/include/ps_types.hpp
+++ b/include/ps_types.hpp
@@ -439,13 +439,56 @@ class OpRegistry {
   std::vector<const OpImplementation*> get_all_implementations(
       const std::string& type, const std::string& subtype) const;
 
-  // 根据 ComputeIntent 和可用设备选择最优实现
-  // @param available_devices 当前可用的设备列表
-  // @param intent 计算意图（HP 或 RT）
-  // @return 最优实现的指针，如果无可用实现则返回 nullptr
+  /**
+   * @brief Selects the best registered implementation for an intent.
+   *
+   * The registry owns the intent-specific ordering policy. It first restricts
+   * candidates to implementations whose `device_preference` is present in
+   * `available_devices`, then orders the remaining candidates by
+   * `ComputeIntent` device priority and `cost_score`.
+   *
+   * @param type Operation type, such as `"image_process"`.
+   * @param subtype Operation subtype, such as `"gaussian_blur"`.
+   * @param available_devices Devices exposed by the active scheduler runtime.
+   * @param intent Compute path selecting the HP or RT priority policy.
+   * @return Pointer to the selected implementation, or nullptr when the key is
+   * missing or no implementation can run on an available device.
+   * @throws std::bad_alloc if temporary candidate storage allocation fails.
+   * @note Returned pointers borrow storage owned by OpRegistry and remain valid
+   * until the matching operation key is unregistered or the registry is mutated
+   * in a way that reallocates that key's implementation vector.
+   */
   const OpImplementation* select_best_implementation(
       const std::string& type, const std::string& subtype,
       const std::vector<Device>& available_devices, ComputeIntent intent) const;
+
+  /**
+   * @brief Selects the best registered implementation after caller filtering.
+   *
+   * This overload applies the same registry-owned device and intent ordering as
+   * the four-argument overload, while allowing a caller to reject candidates
+   * for local execution constraints such as task-shape compatibility. An empty
+   * `candidate_filter` accepts every available-device candidate.
+   *
+   * @param type Operation type, such as `"image_process"`.
+   * @param subtype Operation subtype, such as `"gaussian_blur"`.
+   * @param available_devices Devices exposed by the active scheduler runtime.
+   * @param intent Compute path selecting the HP or RT priority policy.
+   * @param candidate_filter Optional predicate; returning false removes the
+   * candidate before registry ordering is applied.
+   * @return Pointer to the selected implementation, or nullptr when the key is
+   * missing or no available candidate survives filtering.
+   * @throws std::bad_alloc if temporary candidate storage allocation fails.
+   * @throws Any exception thrown by `candidate_filter`.
+   * @note The filter must not mutate OpRegistry or retain references to
+   * candidates beyond the call. Sorting policy remains centralized in
+   * OpRegistry.
+   */
+  const OpImplementation* select_best_implementation(
+      const std::string& type, const std::string& subtype,
+      const std::vector<Device>& available_devices, ComputeIntent intent,
+      const std::function<bool(const OpImplementation&)>& candidate_filter)
+      const;
 
   /**
    * @brief Runs a registration callback while capturing touched keys.

--- a/scheduler_plugins/gpu_pipeline_example_plugin.cpp
+++ b/scheduler_plugins/gpu_pipeline_example_plugin.cpp
@@ -42,7 +42,8 @@ const char* ps_scheduler_plugin_get_description(int index) {
  * scheduler's CPU RT queue through the scheduler's built-in queue topology
  * rather than through a deprecated config flag.
  *
- * @param type_name Scheduler type requested by the plugin loader.
+ * @param type_name Scheduler type requested by the plugin loader; nullptr is
+ * rejected as an unsupported scheduler type.
  * @param num_workers Requested CPU worker count; zero preserves the scheduler's
  * automatic worker-count behavior.
  * @return A heap-allocated scheduler for supported aliases, or nullptr when
@@ -53,6 +54,9 @@ const char* ps_scheduler_plugin_get_description(int index) {
  */
 ps::IScheduler* ps_scheduler_plugin_create(const char* type_name,
                                            unsigned int num_workers) {
+  if (!type_name) {
+    return nullptr;
+  }
   std::string name(type_name);
   if (name == "gpu_pipeline_example" || name == "heterogeneous_example") {
     ps::GpuPipelineScheduler::Config config;

--- a/scheduler_plugins/gpu_pipeline_example_plugin.cpp
+++ b/scheduler_plugins/gpu_pipeline_example_plugin.cpp
@@ -34,6 +34,23 @@ const char* ps_scheduler_plugin_get_description(int index) {
   return (index == 0 || index == 1) ? desc : nullptr;
 }
 
+/**
+ * @brief Creates an example GPU pipeline scheduler plugin instance.
+ *
+ * The example aliases use the active `GpuPipelineScheduler::Config` surface:
+ * HP dispatch may prefer GPU work queues, while RT dispatch stays on the
+ * scheduler's CPU RT queue through the scheduler's built-in queue topology
+ * rather than through a deprecated config flag.
+ *
+ * @param type_name Scheduler type requested by the plugin loader.
+ * @param num_workers Requested CPU worker count; zero preserves the scheduler's
+ * automatic worker-count behavior.
+ * @return A heap-allocated scheduler for supported aliases, or nullptr when
+ * `type_name` is not provided by this plugin.
+ * @throws std::bad_alloc if scheduler allocation fails.
+ * @note Ownership transfers to the plugin loader, which must release the
+ * instance through `ps_scheduler_plugin_destroy()`.
+ */
 ps::IScheduler* ps_scheduler_plugin_create(const char* type_name,
                                            unsigned int num_workers) {
   std::string name(type_name);
@@ -41,7 +58,6 @@ ps::IScheduler* ps_scheduler_plugin_create(const char* type_name,
     ps::GpuPipelineScheduler::Config config;
     config.cpu_workers = num_workers;
     config.prefer_gpu_for_hp = true;
-    config.force_cpu_for_rt = true;
     return new ps::GpuPipelineScheduler(config);
   }
   return nullptr;

--- a/src/kernel/scheduler/gpu_pipeline_scheduler.cpp
+++ b/src/kernel/scheduler/gpu_pipeline_scheduler.cpp
@@ -436,7 +436,7 @@ std::vector<Device> GpuPipelineScheduler::get_available_devices() const {
   std::vector<Device> devices;
   devices.push_back(Device::CPU);
 
-  if (is_gpu_available()) {
+  if (can_dispatch_hp_to_gpu()) {
     devices.push_back(Device::GPU_METAL);
   }
 

--- a/src/kernel/services/compute-service/compute_task_submission.cpp
+++ b/src/kernel/services/compute-service/compute_task_submission.cpp
@@ -63,7 +63,8 @@ std::exception_ptr scheduling_failure(const GraphModel& graph, int node_id,
  * rather than compile-time platform checks.
  */
 bool implementation_device_available(
-    const OpImplementation& impl, const std::vector<Device>& available_devices) {
+    const OpImplementation& impl,
+    const std::vector<Device>& available_devices) {
   return std::find(available_devices.begin(), available_devices.end(),
                    impl.metadata.device_preference) != available_devices.end();
 }
@@ -86,6 +87,50 @@ bool implementation_shape_compatible(const OpImplementation& impl,
 }
 
 /**
+ * @brief Returns the HP implementation device priority used by OpRegistry.
+ *
+ * @param device Candidate implementation device.
+ * @return Lower value for higher GlobalHighPrecision preference.
+ * @throws Nothing.
+ * @note This mirrors OpRegistry::select_best_implementation() for the
+ * shape-filtered fallback path: GPU backends are preferred before accelerators
+ * and CPU, with cost_score used only inside the same priority tier.
+ */
+int high_precision_device_priority(Device device) {
+  if (device == Device::GPU_METAL || device == Device::GPU_CUDA) {
+    return 0;
+  }
+  if (device == Device::ASIC_NPU) {
+    return 1;
+  }
+  return 2;
+}
+
+/**
+ * @brief Orders compatible HP implementations by registry-equivalent priority.
+ *
+ * @param lhs Left compatible implementation candidate.
+ * @param rhs Right compatible implementation candidate.
+ * @return True when lhs should be selected before rhs.
+ * @throws Nothing.
+ * @note The fallback has already filtered by available device and required
+ * task shape. This comparator preserves HP device preference before applying
+ * cost_score, preventing a cheaper CPU tiled implementation from displacing a
+ * GPU tiled implementation when GPU execution is available.
+ */
+bool high_precision_implementation_less(const OpImplementation* lhs,
+                                        const OpImplementation* rhs) {
+  const int lhs_priority =
+      high_precision_device_priority(lhs->metadata.device_preference);
+  const int rhs_priority =
+      high_precision_device_priority(rhs->metadata.device_preference);
+  if (lhs_priority != rhs_priority) {
+    return lhs_priority < rhs_priority;
+  }
+  return lhs->metadata.cost_score < rhs->metadata.cost_score;
+}
+
+/**
  * @brief Chooses a shape-compatible per-device implementation for HP compute.
  *
  * @param node Graph node whose operation is being resolved.
@@ -94,10 +139,11 @@ bool implementation_shape_compatible(const OpImplementation& impl,
  * @return Selected operation variant, or nullopt when no compatible
  * per-device implementation is available.
  * @throws std::bad_alloc if registry helper vectors allocate.
- * @note The primary selection path calls OpRegistry::select_best_implementation.
- * If that best candidate does not match the already materialized task shape,
- * this helper falls back to the lowest-cost compatible implementation instead
- * of handing a monolithic function to a tile task.
+ * @note The primary selection path calls
+ * OpRegistry::select_best_implementation. If that best candidate does not match
+ * the already materialized task shape, this helper falls back to a compatible
+ * implementation using the same HP device priority as OpRegistry before
+ * comparing cost_score.
  */
 std::optional<OpRegistry::OpVariant> select_device_aware_hp_op(
     const Node& node, const std::vector<Device>& available_devices,
@@ -127,11 +173,8 @@ std::optional<OpRegistry::OpVariant> select_device_aware_hp_op(
   if (compatible.empty()) {
     return std::nullopt;
   }
-  auto best_compatible = std::min_element(
-      compatible.begin(), compatible.end(),
-      [](const OpImplementation* lhs, const OpImplementation* rhs) {
-        return lhs->metadata.cost_score < rhs->metadata.cost_score;
-      });
+  auto best_compatible = std::min_element(compatible.begin(), compatible.end(),
+                                          high_precision_implementation_less);
   return (*best_compatible)->func;
 }
 

--- a/src/kernel/services/compute-service/compute_task_submission.cpp
+++ b/src/kernel/services/compute-service/compute_task_submission.cpp
@@ -53,23 +53,6 @@ std::exception_ptr scheduling_failure(const GraphModel& graph, int node_id,
 }
 
 /**
- * @brief Checks whether one implementation can run on an available device.
- *
- * @param impl Registered operation implementation candidate.
- * @param available_devices Devices exposed by the active scheduler runtime.
- * @return True when impl metadata names a device in available_devices.
- * @throws Nothing directly.
- * @note Device selection is intentionally tied to scheduler runtime capability
- * rather than compile-time platform checks.
- */
-bool implementation_device_available(
-    const OpImplementation& impl,
-    const std::vector<Device>& available_devices) {
-  return std::find(available_devices.begin(), available_devices.end(),
-                   impl.metadata.device_preference) != available_devices.end();
-}
-
-/**
  * @brief Checks whether a candidate matches the planned task shape.
  *
  * @param impl Registered operation implementation candidate.
@@ -87,50 +70,6 @@ bool implementation_shape_compatible(const OpImplementation& impl,
 }
 
 /**
- * @brief Returns the HP implementation device priority used by OpRegistry.
- *
- * @param device Candidate implementation device.
- * @return Lower value for higher GlobalHighPrecision preference.
- * @throws Nothing.
- * @note This mirrors OpRegistry::select_best_implementation() for the
- * shape-filtered fallback path: GPU backends are preferred before accelerators
- * and CPU, with cost_score used only inside the same priority tier.
- */
-int high_precision_device_priority(Device device) {
-  if (device == Device::GPU_METAL || device == Device::GPU_CUDA) {
-    return 0;
-  }
-  if (device == Device::ASIC_NPU) {
-    return 1;
-  }
-  return 2;
-}
-
-/**
- * @brief Orders compatible HP implementations by registry-equivalent priority.
- *
- * @param lhs Left compatible implementation candidate.
- * @param rhs Right compatible implementation candidate.
- * @return True when lhs should be selected before rhs.
- * @throws Nothing.
- * @note The fallback has already filtered by available device and required
- * task shape. This comparator preserves HP device preference before applying
- * cost_score, preventing a cheaper CPU tiled implementation from displacing a
- * GPU tiled implementation when GPU execution is available.
- */
-bool high_precision_implementation_less(const OpImplementation* lhs,
-                                        const OpImplementation* rhs) {
-  const int lhs_priority =
-      high_precision_device_priority(lhs->metadata.device_preference);
-  const int rhs_priority =
-      high_precision_device_priority(rhs->metadata.device_preference);
-  if (lhs_priority != rhs_priority) {
-    return lhs_priority < rhs_priority;
-  }
-  return lhs->metadata.cost_score < rhs->metadata.cost_score;
-}
-
-/**
  * @brief Chooses a shape-compatible per-device implementation for HP compute.
  *
  * @param node Graph node whose operation is being resolved.
@@ -138,12 +77,10 @@ bool high_precision_implementation_less(const OpImplementation* lhs,
  * @param require_tiled Whether task graph materialization requires TileOpFunc.
  * @return Selected operation variant, or nullopt when no compatible
  * per-device implementation is available.
- * @throws std::bad_alloc if registry helper vectors allocate.
- * @note The primary selection path calls
- * OpRegistry::select_best_implementation. If that best candidate does not match
- * the already materialized task shape, this helper falls back to a compatible
- * implementation using the same HP device priority as OpRegistry before
- * comparing cost_score.
+ * @throws std::bad_alloc if registry candidate storage allocation fails.
+ * @note The registry owns available-device filtering, HP device priority, and
+ * cost_score tie-breaking. This helper contributes only the local task-shape
+ * predicate required by the already materialized dispatch plan.
  */
 std::optional<OpRegistry::OpVariant> select_device_aware_hp_op(
     const Node& node, const std::vector<Device>& available_devices,
@@ -151,31 +88,14 @@ std::optional<OpRegistry::OpVariant> select_device_aware_hp_op(
   const OpRegistry& registry = OpRegistry::instance();
   const OpImplementation* best = registry.select_best_implementation(
       node.type, node.subtype, available_devices,
-      ComputeIntent::GlobalHighPrecision);
-  if (best && implementation_shape_compatible(*best, require_tiled)) {
-    return best->func;
-  }
-
-  std::vector<const OpImplementation*> compatible;
-  for (const OpImplementation* impl :
-       registry.get_all_implementations(node.type, node.subtype)) {
-    if (!impl) {
-      continue;
-    }
-    if (!implementation_device_available(*impl, available_devices)) {
-      continue;
-    }
-    if (!implementation_shape_compatible(*impl, require_tiled)) {
-      continue;
-    }
-    compatible.push_back(impl);
-  }
-  if (compatible.empty()) {
+      ComputeIntent::GlobalHighPrecision,
+      [require_tiled](const OpImplementation& impl) {
+        return implementation_shape_compatible(impl, require_tiled);
+      });
+  if (!best) {
     return std::nullopt;
   }
-  auto best_compatible = std::min_element(compatible.begin(), compatible.end(),
-                                          high_precision_implementation_less);
-  return (*best_compatible)->func;
+  return best->func;
 }
 
 /**

--- a/src/ps_types.cpp
+++ b/src/ps_types.cpp
@@ -29,6 +29,68 @@ void sort_unique_keys(std::vector<std::string>& keys) {
   keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
 }
 
+/**
+ * @brief Maps one implementation to an intent-specific device priority.
+ *
+ * @param intent Compute path selecting the HP or RT priority policy.
+ * @param device Candidate implementation device.
+ * @param is_tiled Whether the candidate uses the tiled callback shape.
+ * @return Lower values represent higher registry selection priority.
+ * @throws Nothing.
+ * @note GlobalHighPrecision prefers GPU backends, then accelerator backends,
+ * then CPU. RealTimeUpdate prefers tiled CPU callbacks before GPU backends,
+ * preserving the existing low-latency RT policy.
+ */
+int implementation_device_priority(ComputeIntent intent, Device device,
+                                   bool is_tiled) {
+  switch (intent) {
+    case ComputeIntent::GlobalHighPrecision:
+      if (device == Device::GPU_METAL || device == Device::GPU_CUDA) {
+        return 0;
+      }
+      if (device == Device::ASIC_NPU) {
+        return 1;
+      }
+      return 2;
+    case ComputeIntent::RealTimeUpdate:
+      if (device == Device::CPU && is_tiled) {
+        return 0;
+      }
+      if (device == Device::GPU_METAL || device == Device::GPU_CUDA) {
+        return 1;
+      }
+      return 2;
+    default:
+      return 99;
+  }
+}
+
+/**
+ * @brief Orders two implementation candidates by registry policy.
+ *
+ * @param lhs Left candidate borrowed from an OpRegistry implementation vector.
+ * @param rhs Right candidate borrowed from an OpRegistry implementation vector.
+ * @param intent Compute path selecting the HP or RT priority policy.
+ * @return True when `lhs` should sort before `rhs`.
+ * @throws Nothing.
+ * @note Device priority is compared before `cost_score`; equal priorities and
+ * equal costs preserve `std::min_element`'s first-seen candidate selection.
+ */
+bool implementation_less_for_intent(const OpImplementation* lhs,
+                                    const OpImplementation* rhs,
+                                    ComputeIntent intent) {
+  const Device lhs_device = lhs->metadata.device_preference;
+  const Device rhs_device = rhs->metadata.device_preference;
+  const int lhs_priority =
+      implementation_device_priority(intent, lhs_device, lhs->is_tiled());
+  const int rhs_priority =
+      implementation_device_priority(intent, rhs_device, rhs->is_tiled());
+  if (lhs_priority != rhs_priority) {
+    return lhs_priority < rhs_priority;
+  }
+  return lhs->metadata.cost_score < rhs->metadata.cost_score;
+}
+
 }  // namespace
 
 OpRegistry& OpRegistry::instance() {
@@ -500,6 +562,16 @@ std::vector<const OpImplementation*> OpRegistry::get_all_implementations(
 const OpImplementation* OpRegistry::select_best_implementation(
     const std::string& type, const std::string& subtype,
     const std::vector<Device>& available_devices, ComputeIntent intent) const {
+  return select_best_implementation(
+      type, subtype, available_devices, intent,
+      std::function<bool(const OpImplementation&)>{});
+}
+
+const OpImplementation* OpRegistry::select_best_implementation(
+    const std::string& type, const std::string& subtype,
+    const std::vector<Device>& available_devices, ComputeIntent intent,
+    const std::function<bool(const OpImplementation&)>& candidate_filter)
+    const {
   auto key = make_key(type, subtype);
   auto it = impl_table_.find(key);
   if (it == impl_table_.end()) {
@@ -513,6 +585,9 @@ const OpImplementation* OpRegistry::select_best_implementation(
     // 检查实现的设备是否在可用设备列表中
     if (std::find(available_devices.begin(), available_devices.end(),
                   impl_device) != available_devices.end()) {
+      if (candidate_filter && !candidate_filter(impl)) {
+        continue;
+      }
       candidates.push_back(&impl);
     }
   }
@@ -521,50 +596,12 @@ const OpImplementation* OpRegistry::select_best_implementation(
     return nullptr;
   }
 
-  // 根据 ComputeIntent 和 cost_score 排序选择最优实现
-  // HP 模式: 优先 GPU > CPU (Monolithic) > CPU (Tiled)，同设备按 cost_score
-  // RT 模式: 优先 CPU (Tiled) > GPU，同设备按 cost_score
-  auto compare_impl = [intent](const OpImplementation* a,
-                               const OpImplementation* b) {
-    Device da = a->metadata.device_preference;
-    Device db = b->metadata.device_preference;
-
-    // 设备优先级映射
-    auto device_priority = [intent](Device d, bool is_tiled) -> int {
-      switch (intent) {
-        case ComputeIntent::GlobalHighPrecision:
-          // HP: GPU > CPU
-          if (d == Device::GPU_METAL || d == Device::GPU_CUDA)
-            return 0;
-          if (d == Device::ASIC_NPU)
-            return 1;
-          return 2;  // CPU
-        case ComputeIntent::RealTimeUpdate:
-          // RT: CPU Tiled > GPU (低延迟优先)
-          if (d == Device::CPU && is_tiled)
-            return 0;
-          if (d == Device::GPU_METAL || d == Device::GPU_CUDA)
-            return 1;
-          return 2;
-        default:
-          return 99;
-      }
-    };
-
-    int prio_a = device_priority(da, a->is_tiled());
-    int prio_b = device_priority(db, b->is_tiled());
-
-    if (prio_a != prio_b) {
-      return prio_a < prio_b;  // 优先级小的排前面
-    }
-
-    // 同优先级按 cost_score 排序
-    return a->metadata.cost_score < b->metadata.cost_score;
-  };
-
   // 找出最优实现
-  auto best_it =
-      std::min_element(candidates.begin(), candidates.end(), compare_impl);
+  auto best_it = std::min_element(
+      candidates.begin(), candidates.end(),
+      [intent](const OpImplementation* lhs, const OpImplementation* rhs) {
+        return implementation_less_for_intent(lhs, rhs, intent);
+      });
   return *best_it;
 }
 

--- a/tests/test_gpu_pipeline_scheduler.cpp
+++ b/tests/test_gpu_pipeline_scheduler.cpp
@@ -10,12 +10,14 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <future>
 #include <thread>
 #include <vector>
 
+#include "adapter/buffer_adapter_opencv.hpp"
 #include "kernel/graph_runtime.hpp"
 #include "kernel/interaction.hpp"
 #include "kernel/kernel.hpp"
@@ -137,6 +139,44 @@ NodeOutput production_gpu_marker_op(
   output.image_buffer.type = DataType::FLOAT32;
   output.image_buffer.device = Device::GPU_METAL;
   return output;
+}
+
+/**
+ * @brief CPU tiled marker used to catch incorrect fallback selection.
+ *
+ * @param node Node being computed, unused by the marker.
+ * @param output_tile Destination tile whose buffer is tagged as CPU.
+ * @param input_tiles Resolved input tiles, unused for generator tests.
+ * @throws OpenCV exceptions if the destination tile cannot be viewed.
+ * @note The callback writes a visible pixel value and device tag so production
+ * compute tests can identify which compatible tiled implementation ran.
+ */
+void production_cpu_tiled_marker_op(const Node& node,
+                                    const OutputTile& output_tile,
+                                    const std::vector<InputTile>& input_tiles) {
+  (void)node;
+  (void)input_tiles;
+  output_tile.buffer->device = Device::CPU;
+  toCvMat(output_tile).setTo(1.0f);
+}
+
+/**
+ * @brief GPU tiled marker used to prove fallback preserves HP device priority.
+ *
+ * @param node Node being computed, unused by the marker.
+ * @param output_tile Destination tile whose buffer is tagged as GPU_METAL.
+ * @param input_tiles Resolved input tiles, unused for generator tests.
+ * @throws OpenCV exceptions if the destination tile cannot be viewed.
+ * @note The callback does not require real Metal execution; it marks the
+ * selected implementation path while the test scheduler runs tasks serially.
+ */
+void production_gpu_tiled_marker_op(const Node& node,
+                                    const OutputTile& output_tile,
+                                    const std::vector<InputTile>& input_tiles) {
+  (void)node;
+  (void)input_tiles;
+  output_tile.buffer->device = Device::GPU_METAL;
+  toCvMat(output_tile).setTo(2.0f);
 }
 
 class GpuPipelineSchedulerTest : public ::testing::Test {
@@ -296,17 +336,16 @@ TEST_F(GpuPipelineSchedulerTest, ProductionComputeUsesDeviceImplementation) {
   OpMetadata cpu_meta;
   cpu_meta.device_preference = Device::CPU;
   cpu_meta.cost_score = 100;
-  registry.register_impl(kType, kSubtype, Device::CPU,
-                         production_cpu_marker_op, cpu_meta);
+  registry.register_impl(kType, kSubtype, Device::CPU, production_cpu_marker_op,
+                         cpu_meta);
 
   GraphRuntime::Info info;
   info.name = "device-routing-production";
   info.root = "build/test-device-routing-production";
   info.cache_root = "build/test-device-routing-production/cache";
   GraphRuntime runtime(info);
-  runtime.set_scheduler(
-      ComputeIntent::GlobalHighPrecision,
-      std::make_unique<GpuAvailableSerialScheduler>());
+  runtime.set_scheduler(ComputeIntent::GlobalHighPrecision,
+                        std::make_unique<GpuAvailableSerialScheduler>());
   runtime.start();
 
   Node node;
@@ -326,14 +365,117 @@ TEST_F(GpuPipelineSchedulerTest, ProductionComputeUsesDeviceImplementation) {
   request.cache.force_recache = true;
   request.cache.disable_disk_cache = true;
 
-  NodeOutput& result = compute.compute_parallel(runtime.model(), runtime,
-                                                request);
+  NodeOutput& result =
+      compute.compute_parallel(runtime.model(), runtime, request);
   EXPECT_EQ(result.image_buffer.device, Device::GPU_METAL);
   EXPECT_EQ(result.image_buffer.width, 8);
   EXPECT_EQ(result.image_buffer.height, 8);
 
   runtime.stop();
   registry.unregister_key(make_key(kType, kSubtype));
+}
+
+TEST_F(GpuPipelineSchedulerTest,
+       ProductionTiledFallbackPreservesHpDevicePriority) {
+  constexpr const char* kType = "image_generator";
+  constexpr const char* kSubtype = "tiled_device_priority_fallback";
+  auto& registry = OpRegistry::instance();
+  registry.unregister_key(make_key(kType, kSubtype));
+
+  OpMetadata gpu_monolithic_meta;
+  gpu_monolithic_meta.device_preference = Device::GPU_METAL;
+  gpu_monolithic_meta.cost_score = 1;
+  registry.register_impl(kType, kSubtype, Device::GPU_METAL,
+                         production_gpu_marker_op, gpu_monolithic_meta);
+
+  OpMetadata cpu_tiled_meta;
+  cpu_tiled_meta.device_preference = Device::CPU;
+  cpu_tiled_meta.cost_score = 5;
+  cpu_tiled_meta.tile_preference = TileSizePreference::MICRO;
+  registry.register_impl(kType, kSubtype, Device::CPU,
+                         production_cpu_tiled_marker_op, cpu_tiled_meta);
+
+  OpMetadata gpu_tiled_meta;
+  gpu_tiled_meta.device_preference = Device::GPU_METAL;
+  gpu_tiled_meta.cost_score = 100;
+  gpu_tiled_meta.tile_preference = TileSizePreference::MICRO;
+  registry.register_impl(kType, kSubtype, Device::GPU_METAL,
+                         production_gpu_tiled_marker_op, gpu_tiled_meta);
+
+  GraphRuntime::Info info;
+  info.name = "tiled-device-priority-fallback";
+  info.root = "build/test-tiled-device-priority-fallback";
+  info.cache_root = "build/test-tiled-device-priority-fallback/cache";
+  GraphRuntime runtime(info);
+  runtime.set_scheduler(ComputeIntent::GlobalHighPrecision,
+                        std::make_unique<GpuAvailableSerialScheduler>());
+  runtime.start();
+
+  Node node;
+  node.id = 1;
+  node.name = "tiled_device_route";
+  node.type = kType;
+  node.subtype = kSubtype;
+  node.parameters["width"] = 32;
+  node.parameters["height"] = 32;
+  runtime.model().add_node(node);
+
+  GraphTraversalService traversal;
+  GraphCacheService cache;
+  ComputeService compute(traversal, cache, runtime.event_service());
+  ComputeService::Request request;
+  request.node_id = node.id;
+  request.cache.force_recache = true;
+  request.cache.disable_disk_cache = true;
+
+  NodeOutput& result =
+      compute.compute_parallel(runtime.model(), runtime, request);
+  ASSERT_TRUE(runtime.model().last_compute_plan.has_value());
+  const auto& tasks = runtime.model().last_compute_plan->task_graph.tasks;
+  EXPECT_TRUE(std::any_of(tasks.begin(), tasks.end(), [](const auto& task) {
+    return task.kind == ps::compute::PlannedTaskKind::Tile;
+  }));
+  EXPECT_EQ(result.image_buffer.device, Device::GPU_METAL);
+  EXPECT_EQ(result.debug.compute_device, "GPU_METAL");
+  EXPECT_EQ(toCvMat(result.image_buffer).at<float>(0, 0), 2.0f);
+
+  runtime.stop();
+  registry.unregister_key(make_key(kType, kSubtype));
+}
+
+TEST_F(GpuPipelineSchedulerTest, AvailableDevicesHonorGpuDispatchConfig) {
+  GraphRuntime::Info info;
+  info.name = "available-device-config";
+  info.root = "build/test-available-device-config";
+  info.cache_root = "build/test-available-device-config/cache";
+  GraphRuntime runtime(info);
+  if (runtime.get_metal_device() == nullptr) {
+    GTEST_SKIP() << "Metal device is unavailable on this host.";
+  }
+
+  GpuPipelineScheduler::Config disabled_workers;
+  disabled_workers.gpu_workers = 0;
+  disabled_workers.prefer_gpu_for_hp = true;
+  GpuPipelineScheduler no_gpu_workers(disabled_workers);
+  no_gpu_workers.attach(&runtime);
+  EXPECT_EQ(no_gpu_workers.available_devices(),
+            std::vector<Device>{Device::CPU});
+
+  GpuPipelineScheduler::Config cpu_hp_config;
+  cpu_hp_config.gpu_workers = 1;
+  cpu_hp_config.prefer_gpu_for_hp = false;
+  GpuPipelineScheduler cpu_hp_scheduler(cpu_hp_config);
+  cpu_hp_scheduler.attach(&runtime);
+  EXPECT_EQ(cpu_hp_scheduler.available_devices(),
+            std::vector<Device>{Device::CPU});
+
+  GpuPipelineScheduler::Config enabled_config;
+  enabled_config.gpu_workers = 1;
+  enabled_config.prefer_gpu_for_hp = true;
+  GpuPipelineScheduler gpu_enabled_scheduler(enabled_config);
+  gpu_enabled_scheduler.attach(&runtime);
+  EXPECT_EQ(gpu_enabled_scheduler.available_devices(),
+            (std::vector<Device>{Device::CPU, Device::GPU_METAL}));
 }
 
 // =============================================================================

--- a/tests/test_op_registry_m31.cpp
+++ b/tests/test_op_registry_m31.cpp
@@ -301,6 +301,66 @@ TEST_F(OpRegistryM31Test, MultipleSameDeviceImplsSortedByCost) {
   EXPECT_EQ(best->metadata.cost_score, 50);
 }
 
+TEST_F(OpRegistryM31Test, FilteredSelectionKeepsHpDevicePriority) {
+  constexpr const char* kType = "m31_filter";
+  constexpr const char* kSubtype = "hp_shape_filtered";
+  auto& registry = OpRegistry::instance();
+  registry.unregister_key(make_key(kType, kSubtype));
+
+  OpMetadata gpu_monolithic_meta;
+  gpu_monolithic_meta.device_preference = Device::GPU_METAL;
+  gpu_monolithic_meta.cost_score = 1;
+  registry.register_impl(kType, kSubtype, Device::GPU_METAL, dummy_metal_op,
+                         gpu_monolithic_meta);
+
+  OpMetadata cpu_tiled_meta;
+  cpu_tiled_meta.device_preference = Device::CPU;
+  cpu_tiled_meta.cost_score = 5;
+  cpu_tiled_meta.tile_preference = TileSizePreference::MICRO;
+  registry.register_impl(kType, kSubtype, Device::CPU, dummy_tiled_cpu_op,
+                         cpu_tiled_meta);
+
+  OpMetadata gpu_tiled_meta;
+  gpu_tiled_meta.device_preference = Device::GPU_METAL;
+  gpu_tiled_meta.cost_score = 100;
+  gpu_tiled_meta.tile_preference = TileSizePreference::MICRO;
+  registry.register_impl(kType, kSubtype, Device::GPU_METAL,
+                         dummy_tiled_metal_op, gpu_tiled_meta);
+
+  const std::vector<Device> available_devices = {Device::CPU,
+                                                 Device::GPU_METAL};
+  const OpImplementation* best = registry.select_best_implementation(
+      kType, kSubtype, available_devices, ComputeIntent::GlobalHighPrecision,
+      [](const OpImplementation& impl) { return impl.is_tiled(); });
+
+  ASSERT_NE(best, nullptr);
+  EXPECT_EQ(best->metadata.device_preference, Device::GPU_METAL);
+  EXPECT_TRUE(best->is_tiled());
+  EXPECT_EQ(best->metadata.cost_score, 100);
+
+  registry.unregister_key(make_key(kType, kSubtype));
+}
+
+TEST_F(OpRegistryM31Test, FilteredSelectionReturnsNullWhenAllRejected) {
+  constexpr const char* kType = "m31_filter";
+  constexpr const char* kSubtype = "reject_all";
+  auto& registry = OpRegistry::instance();
+  registry.unregister_key(make_key(kType, kSubtype));
+
+  OpMetadata cpu_meta;
+  cpu_meta.device_preference = Device::CPU;
+  cpu_meta.cost_score = 10;
+  registry.register_impl(kType, kSubtype, Device::CPU, dummy_cpu_op, cpu_meta);
+
+  const OpImplementation* best = registry.select_best_implementation(
+      kType, kSubtype, {Device::CPU}, ComputeIntent::GlobalHighPrecision,
+      [](const OpImplementation&) { return false; });
+
+  EXPECT_EQ(best, nullptr);
+
+  registry.unregister_key(make_key(kType, kSubtype));
+}
+
 // 测试：向后兼容性 - 传统 API 仍然可用
 TEST_F(OpRegistryM31Test, BackwardCompatibilityWithLegacyAPI) {
   auto& registry = OpRegistry::instance();

--- a/tests/test_scheduler_plugin_loader.cpp
+++ b/tests/test_scheduler_plugin_loader.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 
 #include "kernel/scheduler/scheduler_factory.hpp"
+#include "kernel/scheduler/scheduler_plugin_api.hpp"
 #include "kernel/scheduler/scheduler_plugin_loader.hpp"
 
 #ifdef _WIN32
@@ -189,6 +190,34 @@ TEST_F(SchedulerPluginLoaderTest, FactoryIntegration) {
     auto scheduler = SchedulerFactory::create(type, 2);
     EXPECT_NE(scheduler, nullptr) << "Factory failed to create: " << type;
   }
+}
+
+TEST_F(SchedulerPluginLoaderTest, GpuPipelineExampleCreateRejectsNullTypeName) {
+  const auto plugin_path = scheduler_plugin_path("gpu_pipeline_example_plugin");
+
+  if (!std::filesystem::exists(plugin_path)) {
+    GTEST_SKIP() << "gpu pipeline scheduler plugin was not built";
+  }
+
+#ifdef _WIN32
+  HMODULE test_handle = LoadLibrary(plugin_path.string().c_str());
+  ASSERT_NE(test_handle, nullptr);
+  auto create_scheduler = reinterpret_cast<SchedulerPluginCreateFunc>(
+      GetProcAddress(test_handle, PS_SCHEDULER_PLUGIN_CREATE));
+#else
+  void* test_handle = dlopen(plugin_path.string().c_str(), RTLD_LAZY);
+  ASSERT_NE(test_handle, nullptr) << dlerror();
+  auto create_scheduler = reinterpret_cast<SchedulerPluginCreateFunc>(
+      dlsym(test_handle, PS_SCHEDULER_PLUGIN_CREATE));
+#endif
+  ASSERT_NE(create_scheduler, nullptr);
+  EXPECT_EQ(create_scheduler(nullptr, 0), nullptr);
+
+#ifdef _WIN32
+  FreeLibrary(test_handle);
+#else
+  dlclose(test_handle);
+#endif
 }
 
 // 测试清除插件


### PR DESCRIPTION
## 摘要

- 修复 HP shape-compatible fallback：先保持 `OpRegistry::select_best_implementation()` 等价的设备优先级，再比较 `cost_score`。
- 修复 `GpuPipelineScheduler::available_devices()`：禁用 GPU workers 或关闭 `prefer_gpu_for_hp` 时不再暴露 `GPU_METAL`。
- 增加 GPU pipeline scheduler 回归测试，覆盖 tiled fallback 和 advertised devices 配置门控。

## 关联反馈

- https://github.com/kevin-zf1123/photospider/pull/21#discussion_r3541560332
- https://github.com/kevin-zf1123/photospider/pull/21#discussion_r3541564132

## 验证

- `cmake --build build --target test_gpu_pipeline_scheduler -j`
- `./build/tests/test_gpu_pipeline_scheduler --gtest_filter='GpuPipelineSchedulerTest.ProductionTiledFallbackPreservesHpDevicePriority:GpuPipelineSchedulerTest.AvailableDevicesHonorGpuDispatchConfig:GpuPipelineSchedulerTest.ProductionComputeUsesDeviceImplementation'`
- `./build/tests/test_gpu_pipeline_scheduler`
- `ctest --output-on-failure --test-dir build`
- `git diff --check`