### PR TITLE
[fix] fix plugin tests to use CMake output dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,6 +494,10 @@ if(BUILD_TESTING)
     # Operation plugin manager handle lifetime tests
     add_ps_test(test_plugin_manager tests/test_plugin_manager.cpp)
     target_link_libraries(test_plugin_manager PRIVATE ${CMAKE_DL_LIBS})
+    target_compile_definitions(test_plugin_manager PRIVATE
+        PS_STANDARD_OP_PLUGIN_DIR="${PLUGIN_OUTPUT_DIR}"
+        PS_TEST_OP_PLUGIN_DIR="${TEST_OP_PLUGIN_DIR}"
+    )
     add_dependencies(test_plugin_manager lifecycle_op_plugin
         override_lifecycle_op_plugin ${OP_PLUGIN_TARGETS})
 
@@ -503,6 +507,10 @@ if(BUILD_TESTING)
     # [M3.5] 调度器插件加载器测试
     add_ps_test(test_scheduler_plugin_loader tests/test_scheduler_plugin_loader.cpp)
     target_link_libraries(test_scheduler_plugin_loader PRIVATE ${CMAKE_DL_LIBS})
+    target_compile_definitions(test_scheduler_plugin_loader PRIVATE
+        PS_SCHEDULER_PLUGIN_DIR="${SCHEDULER_PLUGIN_DIR}"
+        PS_TEST_SCHEDULER_PLUGIN_DIR="${TEST_SCHEDULER_PLUGIN_DIR}"
+    )
     add_dependencies(test_scheduler_plugin_loader
         ${SCHEDULER_PLUGIN_TARGETS}
         destroy_count_scheduler_plugin

--- a/tests/test_plugin_manager.cpp
+++ b/tests/test_plugin_manager.cpp
@@ -17,18 +17,54 @@ namespace {
 constexpr const char* kLifecycleType = "plugin_lifecycle";
 constexpr const char* kLifecycleSubtype = "op";
 constexpr const char* kLifecycleKey = "plugin_lifecycle:op";
-constexpr const char* kStandardPluginDir = "build/plugins";
+
+#ifndef PS_STANDARD_OP_PLUGIN_DIR
+#define PS_STANDARD_OP_PLUGIN_DIR "build/plugins"
+#endif
+
+#ifndef PS_TEST_OP_PLUGIN_DIR
+#define PS_TEST_OP_PLUGIN_DIR "build/test_plugins"
+#endif
+
+/**
+ * @brief Returns the CMake output root for test-only operation plugins.
+ *
+ * @return Filesystem path injected by CMake for this test target, or the legacy
+ * `build/test_plugins` fallback when the source is compiled outside CMake.
+ * @throws std::bad_alloc from path string construction.
+ * @note The value is an absolute path in normal CMake builds, which lets the
+ * test run from any working directory and from nested build trees such as
+ * `build/ci`.
+ */
+std::filesystem::path test_op_plugin_dir() {
+  return std::filesystem::path(PS_TEST_OP_PLUGIN_DIR);
+}
+
+/**
+ * @brief Returns the CMake output directory for standard operation plugins.
+ *
+ * @return Filesystem path injected by CMake for standard plugin shared
+ * libraries, or the legacy `build/plugins` fallback outside CMake.
+ * @throws std::bad_alloc from path string construction.
+ * @note Plugin manager lifecycle tests intentionally consume the build output
+ * directory instead of a source-relative `build/` path so CI jobs can choose
+ * any binary directory.
+ */
+std::filesystem::path standard_plugin_dir() {
+  return std::filesystem::path(PS_STANDARD_OP_PLUGIN_DIR);
+}
 
 /**
  * @brief Returns the build output path for the lifecycle op plugin fixture.
  *
- * @return Platform-specific shared library path under `build/test_plugins`.
+ * @return Platform-specific shared library path under `test_op_plugin_dir()`.
  * @throws std::bad_alloc from path string construction.
- * @note Tests run with the repository root as working directory, matching the
- * existing scheduler plugin loader tests.
+ * @note The plugin directory comes from the test target's CMake definitions so
+ * the fixture follows the active binary directory rather than a hard-coded
+ * `build/` tree.
  */
 std::filesystem::path lifecycle_plugin_path() {
-  const std::filesystem::path dir = "build/test_plugins/lifecycle";
+  const std::filesystem::path dir = test_op_plugin_dir() / "lifecycle";
 #if defined(_WIN32)
   return dir / "lifecycle_op_plugin.dll";
 #elif defined(__APPLE__)
@@ -41,13 +77,14 @@ std::filesystem::path lifecycle_plugin_path() {
 /**
  * @brief Returns the build output path for the replacement lifecycle plugin.
  *
- * @return Platform-specific shared library path under `build/test_plugins`.
+ * @return Platform-specific shared library path under `test_op_plugin_dir()`.
  * @throws std::bad_alloc from path string construction.
  * @note The replacement plugin intentionally registers the same operation key
- * as `lifecycle_op_plugin`.
+ * as `lifecycle_op_plugin`, and its directory is injected by CMake for the
+ * active build tree.
  */
 std::filesystem::path override_lifecycle_plugin_path() {
-  const std::filesystem::path dir = "build/test_plugins/override";
+  const std::filesystem::path dir = test_op_plugin_dir() / "override";
 #if defined(_WIN32)
   return dir / "override_lifecycle_op_plugin.dll";
 #elif defined(__APPLE__)
@@ -120,8 +157,9 @@ std::string current_lifecycle_compute_device() {
  * @param key Canonical `type:subtype` operation key.
  * @return True when reported keys contain `key`.
  * @throws Nothing.
- * @note Standard plugins are loaded from `build/plugins`, and this helper keeps
- * test assertions independent from platform-specific shared library suffixes.
+ * @note Standard plugins are loaded from `standard_plugin_dir()`, and this
+ * helper keeps test assertions independent from platform-specific shared
+ * library suffixes.
  */
 bool result_contains_key(const PluginLoadResult& result,
                          const std::string& key) {
@@ -348,12 +386,12 @@ TEST_F(PluginManagerLifecycleTest,
   OpRegistry::instance().unregister_key("io:save");
   OpRegistry::instance().unregister_key("image_generator:perlin_noise_metal");
 
-  ASSERT_TRUE(std::filesystem::exists(kStandardPluginDir))
-      << "standard operation plugin directory was not built: "
-      << kStandardPluginDir;
+  const auto plugin_dir = standard_plugin_dir();
+  ASSERT_TRUE(std::filesystem::exists(plugin_dir))
+      << "standard operation plugin directory was not built: " << plugin_dir;
 
   PluginManager manager;
-  const auto result = manager.load_from_dirs_report({kStandardPluginDir});
+  const auto result = manager.load_from_dirs_report({plugin_dir.string()});
 
   EXPECT_GE(result.loaded, 3) << describe_errors(result.errors);
   EXPECT_TRUE(result.errors.empty()) << describe_errors(result.errors);

--- a/tests/test_scheduler_plugin_loader.cpp
+++ b/tests/test_scheduler_plugin_loader.cpp
@@ -5,6 +5,9 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
 
 #include "kernel/scheduler/scheduler_factory.hpp"
 #include "kernel/scheduler/scheduler_plugin_api.hpp"

--- a/tests/test_scheduler_plugin_loader.cpp
+++ b/tests/test_scheduler_plugin_loader.cpp
@@ -19,10 +19,49 @@
 namespace ps {
 namespace {
 
+#ifndef PS_SCHEDULER_PLUGIN_DIR
+#define PS_SCHEDULER_PLUGIN_DIR "build/schedulers"
+#endif
+
+#ifndef PS_TEST_SCHEDULER_PLUGIN_DIR
+#define PS_TEST_SCHEDULER_PLUGIN_DIR "build/test_schedulers"
+#endif
+
+/**
+ * @brief Returns the CMake output directory for scheduler plugins.
+ *
+ * @param test_fixture True selects the test-only scheduler fixture output
+ * directory; false selects the production/demo scheduler plugin output
+ * directory.
+ * @return Filesystem path injected by CMake for this test target, or the
+ * legacy source-root-relative `build/schedulers` tree when compiled outside
+ * CMake.
+ * @throws std::bad_alloc from path string construction.
+ * @note CMake injects absolute paths during normal builds so the loader tests
+ * can execute from the source tree, the binary tree, or nested CI build
+ * directories without assuming a literal `build/` directory name.
+ */
+std::filesystem::path scheduler_plugin_dir(bool test_fixture = false) {
+  return std::filesystem::path(test_fixture ? PS_TEST_SCHEDULER_PLUGIN_DIR
+                                            : PS_SCHEDULER_PLUGIN_DIR);
+}
+
+/**
+ * @brief Builds the expected shared library path for a scheduler plugin.
+ *
+ * @param stem Platform-independent library target stem without prefix or
+ * extension.
+ * @param test_fixture True when the plugin lives in the test-only scheduler
+ * output directory.
+ * @return Platform-specific plugin path inside `scheduler_plugin_dir()`.
+ * @throws std::bad_alloc from path and filename string construction.
+ * @note The helper mirrors CMake's target output directories instead of using
+ * source-root-relative paths, preserving CI compatibility with arbitrary
+ * `BUILD_DIR` values.
+ */
 std::filesystem::path scheduler_plugin_path(const std::string& stem,
                                             bool test_fixture = false) {
-  const std::filesystem::path dir =
-      test_fixture ? "build/test_schedulers" : "build/schedulers";
+  const std::filesystem::path dir = scheduler_plugin_dir(test_fixture);
 #if defined(_WIN32)
   return dir / (stem + ".dll");
 #elif defined(__APPLE__)
@@ -81,8 +120,8 @@ TEST_F(SchedulerPluginLoaderTest, ScanNonExistentDirectory) {
 TEST_F(SchedulerPluginLoaderTest, ScanSchedulerDirectory) {
   auto& loader = SchedulerPluginLoader::instance();
 
-  // 扫描 build/schedulers 目录
-  size_t count = loader.scan_and_load("build/schedulers");
+  const auto plugin_dir = scheduler_plugin_dir();
+  size_t count = loader.scan_and_load(plugin_dir.string());
 
   EXPECT_GE(count, 3u);
 
@@ -95,8 +134,7 @@ TEST_F(SchedulerPluginLoaderTest, ScanSchedulerDirectory) {
     EXPECT_TRUE(contains_type(types, "gpu_pipeline_example"));
     EXPECT_TRUE(contains_type(types, "heterogeneous_example"));
     EXPECT_FALSE(contains_type(types, "destroy_count_test"))
-        << "test-only scheduler fixture must not be exposed in "
-           "build/schedulers";
+        << "test-only scheduler fixture must not be exposed in " << plugin_dir;
 
     // 打印已加载的类型
     std::cout << "Loaded scheduler types from plugins:\n";
@@ -122,8 +160,7 @@ TEST_F(SchedulerPluginLoaderTest, LoadSinglePlugin) {
 TEST_F(SchedulerPluginLoaderTest, GetDescription) {
   auto& loader = SchedulerPluginLoader::instance();
 
-  // 先加载插件
-  loader.scan_and_load("build/schedulers");
+  loader.scan_and_load(scheduler_plugin_dir().string());
 
   auto types = loader.get_registered_types();
   for (const auto& type : types) {
@@ -137,10 +174,10 @@ TEST_F(SchedulerPluginLoaderTest, GetDescription) {
 TEST_F(SchedulerPluginLoaderTest, CreateSchedulerFromPlugin) {
   auto& loader = SchedulerPluginLoader::instance();
 
-  // 加载插件
-  size_t count = loader.scan_and_load("build/schedulers");
+  const auto plugin_dir = scheduler_plugin_dir();
+  size_t count = loader.scan_and_load(plugin_dir.string());
   if (count == 0) {
-    GTEST_SKIP() << "No plugins found in build/schedulers";
+    GTEST_SKIP() << "No plugins found in " << plugin_dir;
   }
 
   auto types = loader.get_registered_types();
@@ -163,8 +200,7 @@ TEST_F(SchedulerPluginLoaderTest, CreateSchedulerFromPlugin) {
 TEST_F(SchedulerPluginLoaderTest, ListLoadedPlugins) {
   auto& loader = SchedulerPluginLoader::instance();
 
-  // 加载插件
-  loader.scan_and_load("build/schedulers");
+  loader.scan_and_load(scheduler_plugin_dir().string());
 
   auto plugins = loader.list_loaded_plugins();
   std::cout << "Loaded plugins:\n";
@@ -177,8 +213,7 @@ TEST_F(SchedulerPluginLoaderTest, ListLoadedPlugins) {
 TEST_F(SchedulerPluginLoaderTest, FactoryIntegration) {
   auto& loader = SchedulerPluginLoader::instance();
 
-  // 加载插件
-  size_t count = loader.scan_and_load("build/schedulers");
+  size_t count = loader.scan_and_load(scheduler_plugin_dir().string());
   if (count == 0) {
     GTEST_SKIP() << "No plugins found";
   }
@@ -224,8 +259,8 @@ TEST_F(SchedulerPluginLoaderTest, GpuPipelineExampleCreateRejectsNullTypeName) {
 TEST_F(SchedulerPluginLoaderTest, ClearPlugins) {
   auto& loader = SchedulerPluginLoader::instance();
 
-  // 加载插件
-  loader.scan_and_load("build/schedulers");
+  const auto plugin_dir = scheduler_plugin_dir();
+  loader.scan_and_load(plugin_dir.string());
 
   auto before = loader.get_registered_types();
   size_t before_count = before.size();
@@ -237,7 +272,7 @@ TEST_F(SchedulerPluginLoaderTest, ClearPlugins) {
   EXPECT_TRUE(after.empty());
 
   // 可以重新加载
-  loader.scan_and_load("build/schedulers");
+  loader.scan_and_load(plugin_dir.string());
   auto reloaded = loader.get_registered_types();
   EXPECT_EQ(reloaded.size(), before_count);
 }


### PR DESCRIPTION
## Root cause

CI run `28936101192` 的 plugin-load artifact 显示，`test_plugin_manager` 在 `BUILD_DIR=/workspace/build/ci` 的 CI layout 下运行时仍查找源码根相对路径 `build/test_plugins/...` 和 `build/plugins`。实际插件输出在 `build/ci/test_plugins/...` 和 `build/ci/plugins/...`，导致 5 个 `PluginManagerLifecycleTest` 在插件加载前全部因文件不存在失败。

同一个 `plugin_load_test.sh` 后续还会执行 `test_scheduler_plugin_loader`；该测试也硬编码 `build/schedulers` 和 `build/test_schedulers`，所以一并修正测试路径来源，未修改 scheduler 实现代码。

PR #23 首轮 CI healthcheck 后续暴露 `tests/test_scheduler_plugin_loader.cpp` 缺少 `<iostream>`、`<string>` 和 `<vector>` 的直接 include；已补齐。

## 修复

- `CMakeLists.txt` 为 `test_plugin_manager` 注入 `PS_STANDARD_OP_PLUGIN_DIR` 和 `PS_TEST_OP_PLUGIN_DIR`。
- `tests/test_plugin_manager.cpp` 使用带 Doxygen 注释的 helper 读取 CMake 注入路径，保留非 CMake 编译时的旧路径兜底。
- `CMakeLists.txt` 为 `test_scheduler_plugin_loader` 注入 `PS_SCHEDULER_PLUGIN_DIR` 和 `PS_TEST_SCHEDULER_PLUGIN_DIR`。
- `tests/test_scheduler_plugin_loader.cpp` 使用同样的 CMake-backed helper 定位 scheduler 插件输出目录，并补齐直接标准库 include。

## 验证

- `BUILD_DIR=/Users/zhufeng/document/code/photospider-fix-plugin-load/build/ci CI_ARTIFACT_DIR=tests/results/fix-plugin-load-ci-path/ci-plugin-load bash ci/scripts/plugin_load_test.sh`
- `ctest --test-dir build/ci -R PluginManagerLifecycleTest --output-on-failure`
- `git diff --check`
- `CI_BASE_REF=origin/CI/workflow-design CI_ARTIFACT_DIR=tests/results/fix-plugin-load-ci-path/healthcheck-after-include bash ci/scripts/healthcheck.sh`

结果：`PluginManagerLifecycleTest` 5/5 通过，`SchedulerPluginLoaderTest` 12/12 通过，CLI scheduler scan 输出 `plugin loading checks passed.`；本地 healthcheck 的 `git diff --check`、`clang-format --dry-run --Werror` 和 `cpplint` 全部通过。GitHub 新 run 中 `healthcheck` 已通过。

## 证据

证据已保存到 personal overlay，不进入 GitHub-facing diff：

- `tests/results/fix-plugin-load-ci-path/summary.md`
- `tests/results/fix-plugin-load-ci-path/ci-plugin-load/plugin_manager_gtest.log`
- `tests/results/fix-plugin-load-ci-path/ci-plugin-load/scheduler_plugin_loader_gtest.log`
- `tests/results/fix-plugin-load-ci-path/ci-plugin-load/plugin_cli.log`
- `tests/results/fix-plugin-load-ci-path/ctest_plugin_manager.log`
- `tests/results/fix-plugin-load-ci-path/healthcheck-after-include/cpplint_check.log`

## 风险

低风险。改动仅作用于测试目标路径解析和测试文件直接 include，不改变 runtime API 或 plugin loader 实现。
