### PR TITLE
[fix] prevent single-worker scheduler wakeup loss

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,6 +494,10 @@ if(BUILD_TESTING)
     # Operation plugin manager handle lifetime tests
     add_ps_test(test_plugin_manager tests/test_plugin_manager.cpp)
     target_link_libraries(test_plugin_manager PRIVATE ${CMAKE_DL_LIBS})
+    target_compile_definitions(test_plugin_manager PRIVATE
+        PS_STANDARD_OP_PLUGIN_DIR="${PLUGIN_OUTPUT_DIR}"
+        PS_TEST_OP_PLUGIN_DIR="${TEST_OP_PLUGIN_DIR}"
+    )
     add_dependencies(test_plugin_manager lifecycle_op_plugin
         override_lifecycle_op_plugin ${OP_PLUGIN_TARGETS})
 
@@ -503,6 +507,10 @@ if(BUILD_TESTING)
     # [M3.5] 调度器插件加载器测试
     add_ps_test(test_scheduler_plugin_loader tests/test_scheduler_plugin_loader.cpp)
     target_link_libraries(test_scheduler_plugin_loader PRIVATE ${CMAKE_DL_LIBS})
+    target_compile_definitions(test_scheduler_plugin_loader PRIVATE
+        PS_SCHEDULER_PLUGIN_DIR="${SCHEDULER_PLUGIN_DIR}"
+        PS_TEST_SCHEDULER_PLUGIN_DIR="${TEST_SCHEDULER_PLUGIN_DIR}"
+    )
     add_dependencies(test_scheduler_plugin_loader
         ${SCHEDULER_PLUGIN_TARGETS}
         destroy_count_scheduler_plugin

--- a/include/kernel/scheduler/cpu_work_stealing_scheduler.hpp
+++ b/include/kernel/scheduler/cpu_work_stealing_scheduler.hpp
@@ -68,10 +68,23 @@ class CpuWorkStealingScheduler : public IScheduler,
   using Task = SchedulerTaskRuntime::Task;
   using TaskPriority = SchedulerTaskPriority;
 
-  /// @brief 提交初始任务集合，开始一次计算批次
-  /// @param tasks 任务列表
-  /// @param total_task_count 总任务数（包括后续可能动态添加的任务）
-  /// @param priority 任务优先级
+  /**
+   * @brief 提交初始任务集合并开始一个新的调度 epoch。
+   *
+   * 该入口重置批次异常状态，递增 active epoch，设置
+   * tasks_to_complete_，然后按优先级发布初始 ready work。高优先级任务进入全局
+   * FIFO 队列；普通优先级任务按 worker 分散到本地队列，并通过
+   * publish_ready_tasks() 在全局等待互斥量下发布 ready 计数，避免单 worker
+   * 已准备睡眠时错过本地队列任务唤醒。
+   *
+   * @param tasks 本批次立即 ready 的回调任务；scheduler 接管其可调用对象。
+   * @param total_task_count
+   * 本批次需要完成的总任务数，包括任务运行期间动态增加的 ready work。
+   * @param priority 初始任务的调度优先级。
+   * @throws std::bad_alloc if queue growth fails while storing callbacks.
+   * @note 调用方必须保证 total_task_count 与任务内部的 dec_tasks_to_complete()
+   * 调用保持一致；空批次会直接通知 completion waiter。
+   */
   void submit_initial_tasks(
       std::vector<Task>&& tasks, int total_task_count,
       TaskPriority priority = TaskPriority::Normal) override;
@@ -79,7 +92,13 @@ class CpuWorkStealingScheduler : public IScheduler,
   /**
    * @brief 提交初始任务句柄集合，开始一次计算批次。
    *
-   * @param handles 调度器借用的轻量任务句柄列表。
+   * 句柄路径与回调路径共享
+   * epoch、异常重置、完成计数和唤醒语义。高优先级句柄进入 全局 FIFO
+   * 队列；普通句柄进入 per-worker 本地队列，并在所有有效句柄入队后通过
+   * publish_ready_tasks() 发布 ready 数量。这样本地队列可见性与 worker
+   * condition-variable 睡眠判定保持同一个唤醒边界。
+   *
+   * @param handles 调度器借用的轻量任务句柄列表；空句柄会被跳过。
    * @param total_task_count 本批次需要完成的活跃任务数。
    * @param priority 任务优先级。
    * @throws Nothing directly; queue allocation may throw before enqueue.
@@ -202,8 +221,9 @@ class CpuWorkStealingScheduler : public IScheduler,
    * The loop prefers high-priority global work, then local normal work, then
    * global normal work, and finally stolen work from peer queues. When no work
    * is visible, the worker parks on cv_task_available_ using
-   * global_queues_mutex_ so shutdown can publish the stop state without losing
-   * the wakeup.
+   * global_queues_mutex_. All local-queue publishers must update
+   * ready_task_count_ through publish_ready_tasks() under that same mutex so a
+   * single worker cannot miss the only wakeup for ordinary initial work.
    *
    * @param thread_id Stable worker index used for local queue ownership and
    * trace context.
@@ -215,6 +235,26 @@ class CpuWorkStealingScheduler : public IScheduler,
 
   // 从其他工作线程窃取任务
   std::optional<ScheduledTask> steal_task(int stealer_id);
+
+  /**
+   * @brief Publishes newly visible local-queue work to idle workers.
+   *
+   * Local normal-priority queues have per-worker mutexes, but idle workers
+   * decide whether to sleep under global_queues_mutex_ by reading
+   * ready_task_count_. This helper updates that predicate while holding the
+   * global mutex, then wakes one or all workers. The ordering closes the
+   * condition-variable lost-wakeup window that matters most when there is only
+   * one worker and no later task submission can send another notification.
+   *
+   * @param count Number of ready tasks made available by the caller.
+   * @param wake_all true to wake all workers for a batch, false to wake one
+   * worker for a single local submission.
+   * @throws Nothing directly.
+   * @note Call after the tasks have been placed in their local queues. If an
+   * already-running worker consumes a task before publication, the later
+   * increment balances that worker's ready_task_count_ decrement.
+   */
+  void publish_ready_tasks(int count, bool wake_all);
 
   // ---------------------------------------------------------------------------
   // 成员变量

--- a/src/kernel/scheduler/cpu_work_stealing_scheduler.cpp
+++ b/src/kernel/scheduler/cpu_work_stealing_scheduler.cpp
@@ -233,6 +233,23 @@ CpuWorkStealingScheduler::steal_task(int stealer_id) {
   return std::nullopt;
 }
 
+void CpuWorkStealingScheduler::publish_ready_tasks(int count, bool wake_all) {
+  if (count <= 0) {
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(global_queues_mutex_);
+    ready_task_count_.fetch_add(count, std::memory_order_release);
+  }
+
+  if (wake_all) {
+    cv_task_available_.notify_all();
+  } else {
+    cv_task_available_.notify_one();
+  }
+}
+
 void CpuWorkStealingScheduler::run_loop(int thread_id) {
   tls_worker_id_ = thread_id;
 
@@ -396,9 +413,7 @@ void CpuWorkStealingScheduler::submit_initial_tasks(std::vector<Task>&& tasks,
           wrap_task(std::move(tasks[i])));
       normal_enqueued_.fetch_add(1, std::memory_order_relaxed);
     }
-    ready_task_count_.fetch_add(static_cast<int>(task_count),
-                                std::memory_order_release);
-    cv_task_available_.notify_all();
+    publish_ready_tasks(static_cast<int>(task_count), true);
   }
 }
 
@@ -431,22 +446,25 @@ void CpuWorkStealingScheduler::submit_initial_task_handles(
     return ScheduledTask(epoch, handle);
   };
 
-  const size_t task_count = handles.size();
   if (priority == TaskPriority::High) {
+    int submitted = 0;
     std::lock_guard<std::mutex> lock(global_queues_mutex_);
     for (TaskHandle handle : handles) {
       if (!handle)
         continue;
       high_priority_queue_.push(wrap_handle(handle));
       high_enqueued_.fetch_add(1, std::memory_order_relaxed);
+      ++submitted;
     }
-    ready_task_count_.fetch_add(static_cast<int>(task_count),
-                                std::memory_order_release);
-    cv_task_available_.notify_all();
+    ready_task_count_.fetch_add(submitted, std::memory_order_release);
+    if (submitted > 0) {
+      cv_task_available_.notify_all();
+    }
     return;
   }
 
   static thread_local std::mt19937 rng(std::random_device{}());
+  int submitted = 0;
   for (TaskHandle handle : handles) {
     if (!handle)
       continue;
@@ -455,10 +473,9 @@ void CpuWorkStealingScheduler::submit_initial_task_handles(
     std::lock_guard<std::mutex> lock(*local_queue_mutexes_[target_thread]);
     local_task_queues_[target_thread].push_back(wrap_handle(handle));
     normal_enqueued_.fetch_add(1, std::memory_order_relaxed);
+    ++submitted;
   }
-  ready_task_count_.fetch_add(static_cast<int>(task_count),
-                              std::memory_order_release);
-  cv_task_available_.notify_all();
+  publish_ready_tasks(submitted, true);
 }
 
 void CpuWorkStealingScheduler::submit_ready_task_any_thread(
@@ -574,9 +591,8 @@ void CpuWorkStealingScheduler::submit_ready_task_from_worker(
       std::lock_guard<std::mutex> lock(*local_queue_mutexes_[worker_id]);
       local_task_queues_[worker_id].push_back(std::move(scheduled));
       normal_enqueued_.fetch_add(1, std::memory_order_relaxed);
-      ready_task_count_.fetch_add(1, std::memory_order_relaxed);
     }
-    cv_task_available_.notify_one();
+    publish_ready_tasks(1, false);
   }
 }
 
@@ -606,9 +622,8 @@ void CpuWorkStealingScheduler::submit_ready_task_handle_from_worker(
       std::lock_guard<std::mutex> lock(*local_queue_mutexes_[worker_id]);
       local_task_queues_[worker_id].push_back(std::move(scheduled));
       normal_enqueued_.fetch_add(1, std::memory_order_relaxed);
-      ready_task_count_.fetch_add(1, std::memory_order_relaxed);
     }
-    cv_task_available_.notify_one();
+    publish_ready_tasks(1, false);
   }
 }
 
@@ -644,15 +659,8 @@ void CpuWorkStealingScheduler::submit_ready_task_handles_from_worker(
       normal_enqueued_.fetch_add(1, std::memory_order_relaxed);
       ++submitted;
     }
-    if (submitted > 0) {
-      ready_task_count_.fetch_add(submitted, std::memory_order_relaxed);
-    }
   }
-  if (submitted > 1) {
-    cv_task_available_.notify_all();
-  } else if (submitted == 1) {
-    cv_task_available_.notify_one();
-  }
+  publish_ready_tasks(submitted, submitted > 1);
 }
 
 void CpuWorkStealingScheduler::dec_tasks_to_complete() {

--- a/tests/test_milestone3.cpp
+++ b/tests/test_milestone3.cpp
@@ -556,6 +556,31 @@ TEST(M33CpuWorkStealingScheduler, SingleWorker) {
   scheduler.shutdown();
 }
 
+TEST(M33CpuWorkStealingScheduler, SingleWorkerRepeatedInitialTasks) {
+  for (int iteration = 0; iteration < 64; ++iteration) {
+    SCOPED_TRACE(iteration);
+    CpuWorkStealingScheduler scheduler(1);
+    scheduler.start();
+
+    std::atomic<int> counter{0};
+
+    std::vector<CpuWorkStealingScheduler::Task> tasks;
+    for (int i = 0; i < 4; ++i) {
+      tasks.push_back([&counter, &scheduler]() {
+        counter.fetch_add(1);
+        scheduler.dec_tasks_to_complete();
+      });
+    }
+
+    scheduler.submit_initial_tasks(std::move(tasks), 4);
+    scheduler.wait_for_completion();
+
+    EXPECT_EQ(counter.load(), 4);
+
+    scheduler.shutdown();
+  }
+}
+
 TEST(M33CpuWorkStealingScheduler, RapidStartStopCycles) {
   CpuWorkStealingScheduler scheduler(2);
 

--- a/tests/test_plugin_manager.cpp
+++ b/tests/test_plugin_manager.cpp
@@ -17,18 +17,54 @@ namespace {
 constexpr const char* kLifecycleType = "plugin_lifecycle";
 constexpr const char* kLifecycleSubtype = "op";
 constexpr const char* kLifecycleKey = "plugin_lifecycle:op";
-constexpr const char* kStandardPluginDir = "build/plugins";
+
+#ifndef PS_STANDARD_OP_PLUGIN_DIR
+#define PS_STANDARD_OP_PLUGIN_DIR "build/plugins"
+#endif
+
+#ifndef PS_TEST_OP_PLUGIN_DIR
+#define PS_TEST_OP_PLUGIN_DIR "build/test_plugins"
+#endif
+
+/**
+ * @brief Returns the CMake output root for test-only operation plugins.
+ *
+ * @return Filesystem path injected by CMake for this test target, or the legacy
+ * `build/test_plugins` fallback when the source is compiled outside CMake.
+ * @throws std::bad_alloc from path string construction.
+ * @note The value is an absolute path in normal CMake builds, which lets the
+ * test run from any working directory and from nested build trees such as
+ * `build/ci`.
+ */
+std::filesystem::path test_op_plugin_dir() {
+  return std::filesystem::path(PS_TEST_OP_PLUGIN_DIR);
+}
+
+/**
+ * @brief Returns the CMake output directory for standard operation plugins.
+ *
+ * @return Filesystem path injected by CMake for standard plugin shared
+ * libraries, or the legacy `build/plugins` fallback outside CMake.
+ * @throws std::bad_alloc from path string construction.
+ * @note Plugin manager lifecycle tests intentionally consume the build output
+ * directory instead of a source-relative `build/` path so CI jobs can choose
+ * any binary directory.
+ */
+std::filesystem::path standard_plugin_dir() {
+  return std::filesystem::path(PS_STANDARD_OP_PLUGIN_DIR);
+}
 
 /**
  * @brief Returns the build output path for the lifecycle op plugin fixture.
  *
- * @return Platform-specific shared library path under `build/test_plugins`.
+ * @return Platform-specific shared library path under `test_op_plugin_dir()`.
  * @throws std::bad_alloc from path string construction.
- * @note Tests run with the repository root as working directory, matching the
- * existing scheduler plugin loader tests.
+ * @note The plugin directory comes from the test target's CMake definitions so
+ * the fixture follows the active binary directory rather than a hard-coded
+ * `build/` tree.
  */
 std::filesystem::path lifecycle_plugin_path() {
-  const std::filesystem::path dir = "build/test_plugins/lifecycle";
+  const std::filesystem::path dir = test_op_plugin_dir() / "lifecycle";
 #if defined(_WIN32)
   return dir / "lifecycle_op_plugin.dll";
 #elif defined(__APPLE__)
@@ -41,13 +77,14 @@ std::filesystem::path lifecycle_plugin_path() {
 /**
  * @brief Returns the build output path for the replacement lifecycle plugin.
  *
- * @return Platform-specific shared library path under `build/test_plugins`.
+ * @return Platform-specific shared library path under `test_op_plugin_dir()`.
  * @throws std::bad_alloc from path string construction.
  * @note The replacement plugin intentionally registers the same operation key
- * as `lifecycle_op_plugin`.
+ * as `lifecycle_op_plugin`, and its directory is injected by CMake for the
+ * active build tree.
  */
 std::filesystem::path override_lifecycle_plugin_path() {
-  const std::filesystem::path dir = "build/test_plugins/override";
+  const std::filesystem::path dir = test_op_plugin_dir() / "override";
 #if defined(_WIN32)
   return dir / "override_lifecycle_op_plugin.dll";
 #elif defined(__APPLE__)
@@ -120,8 +157,9 @@ std::string current_lifecycle_compute_device() {
  * @param key Canonical `type:subtype` operation key.
  * @return True when reported keys contain `key`.
  * @throws Nothing.
- * @note Standard plugins are loaded from `build/plugins`, and this helper keeps
- * test assertions independent from platform-specific shared library suffixes.
+ * @note Standard plugins are loaded from `standard_plugin_dir()`, and this
+ * helper keeps test assertions independent from platform-specific shared
+ * library suffixes.
  */
 bool result_contains_key(const PluginLoadResult& result,
                          const std::string& key) {
@@ -348,12 +386,12 @@ TEST_F(PluginManagerLifecycleTest,
   OpRegistry::instance().unregister_key("io:save");
   OpRegistry::instance().unregister_key("image_generator:perlin_noise_metal");
 
-  ASSERT_TRUE(std::filesystem::exists(kStandardPluginDir))
-      << "standard operation plugin directory was not built: "
-      << kStandardPluginDir;
+  const auto plugin_dir = standard_plugin_dir();
+  ASSERT_TRUE(std::filesystem::exists(plugin_dir))
+      << "standard operation plugin directory was not built: " << plugin_dir;
 
   PluginManager manager;
-  const auto result = manager.load_from_dirs_report({kStandardPluginDir});
+  const auto result = manager.load_from_dirs_report({plugin_dir.string()});
 
   EXPECT_GE(result.loaded, 3) << describe_errors(result.errors);
   EXPECT_TRUE(result.errors.empty()) << describe_errors(result.errors);

--- a/tests/test_scheduler_plugin_loader.cpp
+++ b/tests/test_scheduler_plugin_loader.cpp
@@ -5,6 +5,9 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
 
 #include "kernel/scheduler/scheduler_factory.hpp"
 #include "kernel/scheduler/scheduler_plugin_api.hpp"

--- a/tests/test_scheduler_plugin_loader.cpp
+++ b/tests/test_scheduler_plugin_loader.cpp
@@ -19,10 +19,49 @@
 namespace ps {
 namespace {
 
+#ifndef PS_SCHEDULER_PLUGIN_DIR
+#define PS_SCHEDULER_PLUGIN_DIR "build/schedulers"
+#endif
+
+#ifndef PS_TEST_SCHEDULER_PLUGIN_DIR
+#define PS_TEST_SCHEDULER_PLUGIN_DIR "build/test_schedulers"
+#endif
+
+/**
+ * @brief Returns the CMake output directory for scheduler plugins.
+ *
+ * @param test_fixture True selects the test-only scheduler fixture output
+ * directory; false selects the production/demo scheduler plugin output
+ * directory.
+ * @return Filesystem path injected by CMake for this test target, or the
+ * legacy source-root-relative `build/schedulers` tree when compiled outside
+ * CMake.
+ * @throws std::bad_alloc from path string construction.
+ * @note CMake injects absolute paths during normal builds so the loader tests
+ * can execute from the source tree, the binary tree, or nested CI build
+ * directories without assuming a literal `build/` directory name.
+ */
+std::filesystem::path scheduler_plugin_dir(bool test_fixture = false) {
+  return std::filesystem::path(test_fixture ? PS_TEST_SCHEDULER_PLUGIN_DIR
+                                            : PS_SCHEDULER_PLUGIN_DIR);
+}
+
+/**
+ * @brief Builds the expected shared library path for a scheduler plugin.
+ *
+ * @param stem Platform-independent library target stem without prefix or
+ * extension.
+ * @param test_fixture True when the plugin lives in the test-only scheduler
+ * output directory.
+ * @return Platform-specific plugin path inside `scheduler_plugin_dir()`.
+ * @throws std::bad_alloc from path and filename string construction.
+ * @note The helper mirrors CMake's target output directories instead of using
+ * source-root-relative paths, preserving CI compatibility with arbitrary
+ * `BUILD_DIR` values.
+ */
 std::filesystem::path scheduler_plugin_path(const std::string& stem,
                                             bool test_fixture = false) {
-  const std::filesystem::path dir =
-      test_fixture ? "build/test_schedulers" : "build/schedulers";
+  const std::filesystem::path dir = scheduler_plugin_dir(test_fixture);
 #if defined(_WIN32)
   return dir / (stem + ".dll");
 #elif defined(__APPLE__)
@@ -81,8 +120,8 @@ TEST_F(SchedulerPluginLoaderTest, ScanNonExistentDirectory) {
 TEST_F(SchedulerPluginLoaderTest, ScanSchedulerDirectory) {
   auto& loader = SchedulerPluginLoader::instance();
 
-  // 扫描 build/schedulers 目录
-  size_t count = loader.scan_and_load("build/schedulers");
+  const auto plugin_dir = scheduler_plugin_dir();
+  size_t count = loader.scan_and_load(plugin_dir.string());
 
   EXPECT_GE(count, 3u);
 
@@ -95,8 +134,7 @@ TEST_F(SchedulerPluginLoaderTest, ScanSchedulerDirectory) {
     EXPECT_TRUE(contains_type(types, "gpu_pipeline_example"));
     EXPECT_TRUE(contains_type(types, "heterogeneous_example"));
     EXPECT_FALSE(contains_type(types, "destroy_count_test"))
-        << "test-only scheduler fixture must not be exposed in "
-           "build/schedulers";
+        << "test-only scheduler fixture must not be exposed in " << plugin_dir;
 
     // 打印已加载的类型
     std::cout << "Loaded scheduler types from plugins:\n";
@@ -122,8 +160,7 @@ TEST_F(SchedulerPluginLoaderTest, LoadSinglePlugin) {
 TEST_F(SchedulerPluginLoaderTest, GetDescription) {
   auto& loader = SchedulerPluginLoader::instance();
 
-  // 先加载插件
-  loader.scan_and_load("build/schedulers");
+  loader.scan_and_load(scheduler_plugin_dir().string());
 
   auto types = loader.get_registered_types();
   for (const auto& type : types) {
@@ -137,10 +174,10 @@ TEST_F(SchedulerPluginLoaderTest, GetDescription) {
 TEST_F(SchedulerPluginLoaderTest, CreateSchedulerFromPlugin) {
   auto& loader = SchedulerPluginLoader::instance();
 
-  // 加载插件
-  size_t count = loader.scan_and_load("build/schedulers");
+  const auto plugin_dir = scheduler_plugin_dir();
+  size_t count = loader.scan_and_load(plugin_dir.string());
   if (count == 0) {
-    GTEST_SKIP() << "No plugins found in build/schedulers";
+    GTEST_SKIP() << "No plugins found in " << plugin_dir;
   }
 
   auto types = loader.get_registered_types();
@@ -163,8 +200,7 @@ TEST_F(SchedulerPluginLoaderTest, CreateSchedulerFromPlugin) {
 TEST_F(SchedulerPluginLoaderTest, ListLoadedPlugins) {
   auto& loader = SchedulerPluginLoader::instance();
 
-  // 加载插件
-  loader.scan_and_load("build/schedulers");
+  loader.scan_and_load(scheduler_plugin_dir().string());
 
   auto plugins = loader.list_loaded_plugins();
   std::cout << "Loaded plugins:\n";
@@ -177,8 +213,7 @@ TEST_F(SchedulerPluginLoaderTest, ListLoadedPlugins) {
 TEST_F(SchedulerPluginLoaderTest, FactoryIntegration) {
   auto& loader = SchedulerPluginLoader::instance();
 
-  // 加载插件
-  size_t count = loader.scan_and_load("build/schedulers");
+  size_t count = loader.scan_and_load(scheduler_plugin_dir().string());
   if (count == 0) {
     GTEST_SKIP() << "No plugins found";
   }
@@ -224,8 +259,8 @@ TEST_F(SchedulerPluginLoaderTest, GpuPipelineExampleCreateRejectsNullTypeName) {
 TEST_F(SchedulerPluginLoaderTest, ClearPlugins) {
   auto& loader = SchedulerPluginLoader::instance();
 
-  // 加载插件
-  loader.scan_and_load("build/schedulers");
+  const auto plugin_dir = scheduler_plugin_dir();
+  loader.scan_and_load(plugin_dir.string());
 
   auto before = loader.get_registered_types();
   size_t before_count = before.size();
@@ -237,7 +272,7 @@ TEST_F(SchedulerPluginLoaderTest, ClearPlugins) {
   EXPECT_TRUE(after.empty());
 
   // 可以重新加载
-  loader.scan_and_load("build/schedulers");
+  loader.scan_and_load(plugin_dir.string());
   auto reloaded = loader.get_registered_types();
   EXPECT_EQ(reloaded.size(), before_count);
 }


### PR DESCRIPTION
## Summary

Fixes the CI full CTest hang observed at `M33CpuWorkStealingScheduler.SingleWorker` in run `28936101192`, and updates this PR branch so its plugin-load/full-ctest checks pass independently against `CI/workflow-design`.

The scheduler previously published normal-priority local-queue work by updating `ready_task_count_` outside the mutex used by idle workers to decide whether to sleep. With a single worker, that left a lost-wakeup window: the worker could observe no ready work and park while the submitting thread had already sent the only notification.

PR #24's first CI run progressed past the scheduler hang but still failed plugin-load/full-ctest because this branch did not yet include PR #23's CMake plugin output directory fix. Those plugin path commits are now cherry-picked into this branch so #24 can run green before #23 is merged.

## Changes

- Adds `CpuWorkStealingScheduler::publish_ready_tasks()` to publish local ready counts under `global_queues_mutex_` before notifying workers.
- Routes normal local submissions through the same publication boundary.
- Counts only valid `TaskHandle`s when publishing initial handle work.
- Adds `M33CpuWorkStealingScheduler.SingleWorkerRepeatedInitialTasks` as regression coverage.
- Updates scheduler Doxygen comments for the wakeup/lifecycle constraint.
- Includes PR #23's plugin test path fixes and direct test includes so plugin-load and full CTest no longer depend on a literal source-root `build/` tree.

## Validation

Evidence is saved under `tests/results/fix-ctest-single-worker-hang/` in the personal overlay worktree.

- `cmake --build build/ci --target test_milestone3 -j`
- `ctest --test-dir build/ci -R '^M33CpuWorkStealingScheduler\.(SingleWorker|SingleWorkerRepeatedInitialTasks)$' --repeat until-fail:50 --output-on-failure --timeout 20`
- `ctest --test-dir build/ci -R '^M33CpuWorkStealingScheduler\.' --output-on-failure --timeout 20`
- `BUILD_DIR=/Users/zhufeng/document/code/photospider-fix-ctest-single-worker/build/ci CI_ARTIFACT_DIR=tests/results/fix-ctest-single-worker-hang/ci-plugin-load-after-plugin-sync bash ci/scripts/plugin_load_test.sh`
- `BUILD_DIR=/Users/zhufeng/document/code/photospider-fix-ctest-single-worker/build/ci CI_ARTIFACT_DIR=tests/results/fix-ctest-single-worker-hang/ctest-full-after-plugin-sync bash ci/scripts/ctest_full.sh`
- `CI_BASE_REF=origin/CI/workflow-design CI_ARTIFACT_DIR=tests/results/fix-ctest-single-worker-hang/healthcheck-after-plugin-sync bash ci/scripts/healthcheck.sh`

Results: focused scheduler repeat passed 50x; `plugin_load_test.sh` passed `PluginManagerLifecycleTest` 5/5, `SchedulerPluginLoaderTest` 12/12, and CLI plugin scan; full CTest passed 158/158 with `SplitComputeServiceRuntimeTrace` excluded by the CI script; healthcheck passed whitespace, clang-format, and cpplint for the full PR diff.

## Risk

Medium: scheduler concurrency semantics changed. Focused repeat, M33 scheduler coverage, plugin-load, healthcheck, and full CTest all pass locally. This PR currently duplicates PR #23's plugin-path commits so it can pass against `CI/workflow-design`; if #23 merges first, #24 can be rebased to reduce duplicate review diff.
