### PR TITLE
chore(ci): split integration build and smoke jobs

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -109,9 +109,41 @@ jobs:
           path: CI-results/ci-image-change
           if-no-files-found: warn
 
-  build-integrity:
+  integration-plan:
     needs: ci-image-change
     if: needs.ci-image-change.outputs.changed != 'true'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}/photospider-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      has_static_product_consumer_smoke: ${{ steps.plan.outputs.has_static_product_consumer_smoke }}
+      has_ipc_disabled_install_smoke: ${{ steps.plan.outputs.has_ipc_disabled_install_smoke }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.repo.full_name || github.repository }}
+          fetch-depth: 0
+          submodules: recursive
+          ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.sha || github.sha }}
+      - name: Plan integration jobs
+        id: plan
+        env:
+          CI_ARTIFACT_DIR: ${{ github.workspace }}/CI-results/integration-plan
+        run: bash ci/scripts/integration_plan.sh
+      - name: Upload integration plan logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-plan-results
+          path: CI-results/integration-plan
+          if-no-files-found: warn
+
+  build-integrity-default:
+    needs: integration-plan
+    if: needs.integration-plan.result == 'success'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}/photospider-ci:latest
@@ -127,24 +159,67 @@ jobs:
           ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.sha || github.sha }}
       - name: Run build integrity
         env:
-          CI_ARTIFACT_DIR: ${{ github.workspace }}/CI-results/build-integrity
+          CI_ARTIFACT_DIR: ${{ github.workspace }}/CI-results/build-integrity-default
+          CI_BUILD_PROFILE: default
         run: bash ci/scripts/build_integrity.sh
       - name: Pack reusable build
         run: |
-          mkdir -p CI-results/reusable-build
-          tar -C build -czf CI-results/reusable-build/ci-build.tar.gz ci
+          mkdir -p CI-results/reusable-build-default
+          tar -C build -czf CI-results/reusable-build-default/ci-build.tar.gz ci
       - name: Upload build integrity logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: build-integrity-results
-          path: CI-results/build-integrity
+          name: build-integrity-default-results
+          path: CI-results/build-integrity-default
           if-no-files-found: warn
       - name: Upload reusable build
         uses: actions/upload-artifact@v4
         with:
-          name: ci-build-dir
-          path: CI-results/reusable-build/ci-build.tar.gz
+          name: ci-build-default
+          path: CI-results/reusable-build-default/ci-build.tar.gz
+          if-no-files-found: error
+          retention-days: 3
+          compression-level: 0
+
+  build-integrity-ipc-disabled:
+    needs: integration-plan
+    if: needs.integration-plan.outputs.has_ipc_disabled_install_smoke == 'true'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}/photospider-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.repo.full_name || github.repository }}
+          fetch-depth: 0
+          submodules: recursive
+          ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.sha || github.sha }}
+      - name: Run build integrity
+        env:
+          CI_ARTIFACT_DIR: ${{ github.workspace }}/CI-results/build-integrity-ipc-disabled
+          CI_BUILD_PROFILE: ipc-disabled
+        run: bash ci/scripts/build_integrity.sh
+      - name: Pack reusable build
+        run: |
+          mkdir -p CI-results/reusable-build-ipc-disabled
+          tar -C build -czf \
+            CI-results/reusable-build-ipc-disabled/ci-build.tar.gz ci
+      - name: Upload build integrity logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-integrity-ipc-disabled-results
+          path: CI-results/build-integrity-ipc-disabled
+          if-no-files-found: warn
+      - name: Upload reusable build
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-build-ipc-disabled
+          path: CI-results/reusable-build-ipc-disabled/ci-build.tar.gz
           if-no-files-found: error
           retention-days: 3
           compression-level: 0
@@ -185,7 +260,7 @@ jobs:
           if-no-files-found: warn
 
   full-ctest:
-    needs: build-integrity
+    needs: [integration-plan, build-integrity-default]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}/photospider-ci:latest
@@ -202,7 +277,7 @@ jobs:
       - name: Download reusable build
         uses: actions/download-artifact@v4
         with:
-          name: ci-build-dir
+          name: ci-build-default
           path: CI-results/reusable-build
       - name: Restore reusable build
         run: |
@@ -222,8 +297,92 @@ jobs:
           path: CI-results/ctest-full
           if-no-files-found: warn
 
+  static-product-consumer-smoke:
+    needs: [integration-plan, build-integrity-default]
+    if: needs.integration-plan.outputs.has_static_product_consumer_smoke == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: ghcr.io/${{ github.repository }}/photospider-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.repo.full_name || github.repository }}
+          fetch-depth: 0
+          submodules: recursive
+          ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.sha || github.sha }}
+      - name: Download reusable build
+        uses: actions/download-artifact@v4
+        with:
+          name: ci-build-default
+          path: CI-results/reusable-build
+      - name: Restore reusable build
+        run: |
+          rm -rf build/ci
+          mkdir -p build
+          tar -C build -xzf CI-results/reusable-build/ci-build.tar.gz
+      - name: Run static product consumer smoke test
+        env:
+          CI_ARTIFACT_DIR: ${{ github.workspace }}/CI-results/static-product-consumer-smoke
+          CI_BUILD_PROFILE: default
+          CI_REUSE_BUILD: ON
+          SMOKE_TEST: static-product-consumer
+        run: bash ci/scripts/build_smoke_test.sh
+      - name: Upload static product consumer smoke logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: static-product-consumer-smoke-results
+          path: CI-results/static-product-consumer-smoke
+          if-no-files-found: warn
+
+  ipc-disabled-install-smoke:
+    needs: [integration-plan, build-integrity-ipc-disabled]
+    if: needs.integration-plan.outputs.has_ipc_disabled_install_smoke == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      image: ghcr.io/${{ github.repository }}/photospider-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.repo.full_name || github.repository }}
+          fetch-depth: 0
+          submodules: recursive
+          ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.sha || github.sha }}
+      - name: Download reusable build
+        uses: actions/download-artifact@v4
+        with:
+          name: ci-build-ipc-disabled
+          path: CI-results/reusable-build
+      - name: Restore reusable build
+        run: |
+          rm -rf build/ci
+          mkdir -p build
+          tar -C build -xzf CI-results/reusable-build/ci-build.tar.gz
+      - name: Run IPC-disabled install smoke test
+        env:
+          CI_ARTIFACT_DIR: ${{ github.workspace }}/CI-results/ipc-disabled-install-smoke
+          CI_BUILD_PROFILE: ipc-disabled
+          CI_REUSE_BUILD: ON
+          SMOKE_TEST: ipc-disabled-install
+        run: bash ci/scripts/build_smoke_test.sh
+      - name: Upload IPC-disabled install smoke logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ipc-disabled-install-smoke-results
+          path: CI-results/ipc-disabled-install-smoke
+          if-no-files-found: warn
+
   scripted-cli:
-    needs: build-integrity
+    needs: [integration-plan, build-integrity-default]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}/photospider-ci:latest
@@ -240,7 +399,7 @@ jobs:
       - name: Download reusable build
         uses: actions/download-artifact@v4
         with:
-          name: ci-build-dir
+          name: ci-build-default
           path: CI-results/reusable-build
       - name: Restore reusable build
         run: |
@@ -261,7 +420,7 @@ jobs:
           if-no-files-found: warn
 
   propagation-script:
-    needs: build-integrity
+    needs: [integration-plan, build-integrity-default]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}/photospider-ci:latest
@@ -278,7 +437,7 @@ jobs:
       - name: Download reusable build
         uses: actions/download-artifact@v4
         with:
-          name: ci-build-dir
+          name: ci-build-default
           path: CI-results/reusable-build
       - name: Restore reusable build
         run: |
@@ -299,7 +458,7 @@ jobs:
           if-no-files-found: warn
 
   plugin-load:
-    needs: build-integrity
+    needs: [integration-plan, build-integrity-default]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}/photospider-ci:latest
@@ -316,7 +475,7 @@ jobs:
       - name: Download reusable build
         uses: actions/download-artifact@v4
         with:
-          name: ci-build-dir
+          name: ci-build-default
           path: CI-results/reusable-build
       - name: Restore reusable build
         run: |
@@ -337,7 +496,7 @@ jobs:
           if-no-files-found: warn
 
   scheduler-repeat:
-    needs: build-integrity
+    needs: [integration-plan, build-integrity-default]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}/photospider-ci:latest
@@ -354,7 +513,7 @@ jobs:
       - name: Download reusable build
         uses: actions/download-artifact@v4
         with:
-          name: ci-build-dir
+          name: ci-build-default
           path: CI-results/reusable-build
       - name: Restore reusable build
         run: |

--- a/ci/scripts/build_integrity.sh
+++ b/ci/scripts/build_integrity.sh
@@ -8,23 +8,48 @@ source "$SCRIPT_DIR/common.sh"
 
 cd "$REPO_ROOT"
 
-ensure_ci_configured cmake_configure
-ensure_ci_targets build_required_targets \
-  graph_cli \
-  test_propagation \
-  lifecycle_op_plugin \
-  override_lifecycle_op_plugin \
-  destroy_count_scheduler_plugin \
-  cpu_work_stealing_example_plugin \
-  gpu_pipeline_example_plugin \
-  serial_debug_example_plugin
-ensure_ci_all build_all
-mark_ci_build_reusable
-run_logged ctest_discovery ctest -N --test-dir "$BUILD_DIR"
+case "$CI_BUILD_PROFILE" in
+  default)
+    BUILD_TESTING=ON
+    unset PHOTOSPIDER_BUILD_IPC || true
+    ensure_ci_configured cmake_configure
+    run_logged validate_profile_cache require_ci_profile_cache
+    ensure_ci_targets build_required_targets \
+      graph_cli \
+      test_propagation \
+      lifecycle_op_plugin \
+      override_lifecycle_op_plugin \
+      destroy_count_scheduler_plugin \
+      cpu_work_stealing_example_plugin \
+      gpu_pipeline_example_plugin \
+      serial_debug_example_plugin
+    ensure_ci_all build_all
+    run_logged ctest_discovery ctest -N --test-dir "$BUILD_DIR"
 
-total_tests=$(awk '/Total Tests:/ {print $3}' "$CI_ARTIFACT_DIR/ctest_discovery.log" | tail -n 1)
-if [[ -z "$total_tests" || "$total_tests" -le 0 ]]; then
-  echo "CTest discovery did not find any tests." >&2
-  exit 1
-fi
-echo "CTest discovered $total_tests tests." | tee "$CI_ARTIFACT_DIR/summary.log"
+    total_tests=$(
+      awk '/Total Tests:/ {print $3}' \
+        "$CI_ARTIFACT_DIR/ctest_discovery.log" | tail -n 1
+    )
+    if [[ -z "$total_tests" || "$total_tests" -le 0 ]]; then
+      echo "CTest discovery did not find any tests." >&2
+      exit 1
+    fi
+    mark_ci_build_reusable
+    echo "Default profile discovered $total_tests tests." |
+      tee "$CI_ARTIFACT_DIR/summary.log"
+    ;;
+  ipc-disabled)
+    BUILD_TESTING=OFF
+    PHOTOSPIDER_BUILD_IPC=OFF
+    ensure_ci_configured cmake_configure
+    run_logged validate_profile_cache require_ci_profile_cache
+    ensure_ci_targets build_photospider photospider
+    mark_ci_build_reusable
+    echo "IPC-disabled profile built photospider with BUILD_TESTING=OFF and IPC=OFF." |
+      tee "$CI_ARTIFACT_DIR/summary.log"
+    ;;
+  *)
+    echo "Unsupported CI_BUILD_PROFILE: $CI_BUILD_PROFILE" >&2
+    exit 2
+    ;;
+esac

--- a/ci/scripts/build_smoke_test.sh
+++ b/ci/scripts/build_smoke_test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+case "${SMOKE_TEST:-}" in
+  static-product-consumer)
+    expected_profile=default
+    BUILD_TESTING=ON
+    ;;
+  ipc-disabled-install)
+    expected_profile=ipc-disabled
+    BUILD_TESTING=OFF
+    PHOTOSPIDER_BUILD_IPC=OFF
+    ;;
+  *)
+    echo "SMOKE_TEST must be static-product-consumer or ipc-disabled-install." >&2
+    exit 2
+    ;;
+esac
+
+if [[ -n "${CI_BUILD_PROFILE:-}" && "$CI_BUILD_PROFILE" != "$expected_profile" ]]; then
+  echo "SMOKE_TEST=$SMOKE_TEST requires CI_BUILD_PROFILE=$expected_profile." >&2
+  exit 2
+fi
+CI_BUILD_PROFILE=$expected_profile
+
+# shellcheck source=ci/scripts/common.sh
+source "$SCRIPT_DIR/common.sh"
+
+cd "$REPO_ROOT"
+
+if ! ci_reuse_build_enabled || ! ci_build_is_reusable; then
+  echo "Smoke test requires reusable '$expected_profile' build at $BUILD_DIR." >&2
+  exit 1
+fi
+
+case "$SMOKE_TEST" in
+  static-product-consumer)
+    ensure_ci_configured cmake_configure
+    ensure_ci_all build_all
+    run_logged smoke_discovery \
+      ctest -N --test-dir "$BUILD_DIR" -R '^StaticProductConsumerSmoke$'
+    if ! ctest_inventory_has_exact_test \
+      "$CI_ARTIFACT_DIR/smoke_discovery.log" \
+      StaticProductConsumerSmoke; then
+      echo "StaticProductConsumerSmoke is not registered." >&2
+      exit 1
+    fi
+    run_logged static_product_consumer_smoke \
+      ctest --output-on-failure --test-dir "$BUILD_DIR" \
+        -R '^StaticProductConsumerSmoke$'
+    ;;
+  ipc-disabled-install)
+    smoke_script="$REPO_ROOT/tests/integration/ipc_disabled_install_smoke.py"
+    if [[ ! -f "$smoke_script" ]]; then
+      {
+        echo "IpcDisabledInstallSmoke was selected, but its runner is absent:"
+        echo "  $smoke_script"
+        echo "This revision cannot run the IPC-disabled install smoke."
+      } | tee "$CI_ARTIFACT_DIR/missing-smoke-runner.log" >&2
+      exit 1
+    fi
+    ensure_ci_configured cmake_configure
+    ensure_ci_targets build_photospider photospider
+    ipc_smoke_command=(
+      python3 "$smoke_script"
+        --repo "$REPO_ROOT"
+        --work "$CI_ARTIFACT_DIR/work"
+        --cmake-executable "${CMAKE_COMMAND:-cmake}"
+        --config "${CMAKE_BUILD_TYPE:-RelWithDebInfo}"
+        --producer-build "$BUILD_DIR"
+    )
+    if command -v timeout >/dev/null 2>&1; then
+      ipc_smoke_command=(
+        timeout --signal=INT --kill-after=30s \
+          "${CI_IPC_SMOKE_TIMEOUT_SECONDS:-600}" \
+          "${ipc_smoke_command[@]}"
+      )
+    fi
+    run_logged ipc_disabled_install_smoke \
+      "${ipc_smoke_command[@]}"
+    ;;
+esac
+
+echo "Build smoke '$SMOKE_TEST' completed." |
+  tee "$CI_ARTIFACT_DIR/summary.log"

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -8,6 +8,8 @@ BUILD_DIR=${BUILD_DIR:-"$REPO_ROOT/build/ci"}
 CI_ARTIFACT_DIR=${CI_ARTIFACT_DIR:-"$REPO_ROOT/CI-results/$(basename "${0%.sh}")"}
 CI_JOBS=${CI_JOBS:-4}
 CI_REUSE_BUILD=${CI_REUSE_BUILD:-OFF}
+CI_BUILD_PROFILE=${CI_BUILD_PROFILE:-default}
+BUILD_TESTING=${BUILD_TESTING:-ON}
 CI_BUILD_STAMP="$BUILD_DIR/.photospider-ci-build-complete"
 
 mkdir -p "$CI_ARTIFACT_DIR"
@@ -39,13 +41,28 @@ log_reused_step() {
   printf '%s\n' "$message" | tee "$log_file"
 }
 
+# @brief Configure the selected CI profile in the shared build directory.
+# @return The CMake configure process status.
+# @throws Nothing; CMake failures are returned to the caller.
+# @note PHOTOSPIDER_BUILD_IPC is forwarded only when the caller selects it,
+#   which keeps revisions without that option compatible with the default
+#   profile.
 configure_ci_build() {
-  cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
-    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-RelWithDebInfo}" \
-    -DBUILD_TESTING=ON \
-    -DUSE_ASAN="${USE_ASAN:-OFF}" \
-    -DUSE_TSAN="${USE_TSAN:-OFF}" \
+  local configure_args=(
+    -S "$REPO_ROOT"
+    -B "$BUILD_DIR"
+    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-RelWithDebInfo}"
+    -DBUILD_TESTING="$BUILD_TESTING"
+    -DUSE_ASAN="${USE_ASAN:-OFF}"
+    -DUSE_TSAN="${USE_TSAN:-OFF}"
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+  )
+  if [[ -n "${PHOTOSPIDER_BUILD_IPC:-}" ]]; then
+    configure_args+=(
+      -DPHOTOSPIDER_BUILD_IPC="$PHOTOSPIDER_BUILD_IPC"
+    )
+  fi
+  cmake "${configure_args[@]}"
 }
 
 build_ci_targets() {
@@ -63,41 +80,203 @@ ci_reuse_build_enabled() {
   esac
 }
 
-ci_build_is_reusable() {
-  [[ -f "$CI_BUILD_STAMP" && -f "$BUILD_DIR/CMakeCache.txt" ]]
+# @brief Read one exact CMake cache variable from the selected build tree.
+# @param $1 CMake cache key without type or value syntax.
+# @return The cached value on stdout, or nonzero when the key is absent.
+# @throws Nothing; filesystem and parsing failures are represented by status.
+# @note Only the final exact key assignment is used.
+ci_cache_value() {
+  local key=$1
+  local assignment
+  assignment=$(grep -E "^${key}:[^=]+=" "$BUILD_DIR/CMakeCache.txt" |
+    tail -n 1) || return 1
+  [[ -n "$assignment" ]] || return 1
+  printf '%s\n' "${assignment#*=}"
 }
 
+# @brief Validate cache values required by the selected build profile.
+# @return Zero only when BUILD_TESTING and optional IPC state match the profile.
+# @throws Nothing; missing or mismatched cache entries return nonzero.
+# @note The default profile accepts a revision without PHOTOSPIDER_BUILD_IPC,
+#   but requires ON when that option exists.
+ci_profile_cache_is_valid() {
+  local build_testing_value
+  local ipc_value
+  build_testing_value=$(ci_cache_value BUILD_TESTING) || return 1
+  case "$CI_BUILD_PROFILE" in
+    default)
+      [[ "$build_testing_value" == ON ]] || return 1
+      if ipc_value=$(ci_cache_value PHOTOSPIDER_BUILD_IPC); then
+        [[ "$ipc_value" == ON ]]
+      fi
+      ;;
+    ipc-disabled)
+      [[ "$build_testing_value" == OFF ]] || return 1
+      ipc_value=$(ci_cache_value PHOTOSPIDER_BUILD_IPC) || return 1
+      [[ "$ipc_value" == OFF ]]
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# @brief Report a profile-specific CMake cache mismatch.
+# @return Zero for a valid profile cache, otherwise nonzero with a diagnostic.
+# @throws Nothing; validation failures use the return status.
+# @note Call this before compiling or stamping a newly configured profile.
+require_ci_profile_cache() {
+  if ci_profile_cache_is_valid; then
+    return 0
+  fi
+  echo "CMake cache does not match profile '$CI_BUILD_PROFILE': $BUILD_DIR" >&2
+  return 1
+}
+
+# @brief Check whether the build stamp and cache match the requested profile.
+# @return Zero only for a stamped CMake tree of CI_BUILD_PROFILE.
+# @throws Nothing; invalid state returns nonzero.
+# @note Callers that require artifact-only execution must fail when this check
+#   is false instead of silently compiling a replacement tree.
+ci_build_is_reusable() {
+  local build_testing_value
+  local ipc_value
+  [[ -f "$CI_BUILD_STAMP" && -f "$BUILD_DIR/CMakeCache.txt" ]] || return 1
+  ci_profile_cache_is_valid || return 1
+  build_testing_value=$(ci_cache_value BUILD_TESTING) || return 1
+  ipc_value=$(ci_cache_value PHOTOSPIDER_BUILD_IPC 2>/dev/null ||
+    printf 'not-defined\n')
+  grep -Fqx "build_dir=$BUILD_DIR" "$CI_BUILD_STAMP" &&
+    grep -Fqx "source_dir=$REPO_ROOT" "$CI_BUILD_STAMP" &&
+    grep -Fqx "profile=$CI_BUILD_PROFILE" "$CI_BUILD_STAMP" &&
+    grep -Fqx "build_testing=$build_testing_value" "$CI_BUILD_STAMP" &&
+    grep -Fqx "photospider_build_ipc=$ipc_value" "$CI_BUILD_STAMP"
+}
+
+# @brief Stamp a completed profile build for downstream artifact consumers.
+# @return Zero after writing the stamp, or a filesystem command status.
+# @throws Nothing; invalid cache or write failures return nonzero.
+# @note The stamp records configuration identity but contains no credentials.
 mark_ci_build_reusable() {
+  local build_testing_value
+  local ipc_value
+  require_ci_profile_cache || return
+  build_testing_value=$(ci_cache_value BUILD_TESTING) || return
+  ipc_value=$(ci_cache_value PHOTOSPIDER_BUILD_IPC 2>/dev/null ||
+    printf 'not-defined\n')
   mkdir -p "$BUILD_DIR"
   cat > "$CI_BUILD_STAMP" <<EOF
 build_dir=$BUILD_DIR
 source_dir=$REPO_ROOT
+profile=$CI_BUILD_PROFILE
+build_testing=$build_testing_value
+photospider_build_ipc=$ipc_value
 created_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 EOF
 }
 
+# @brief Find one exact CTest name in a captured discovery inventory.
+# @param $1 Path to the ctest -N log.
+# @param $2 Exact test name, without regular-expression interpretation.
+# @return Zero when the exact name is present, otherwise nonzero.
+# @throws Nothing; unreadable inventory files return nonzero through awk.
+# @note Prefix and substring matches are intentionally rejected.
+ctest_inventory_has_exact_test() {
+  local inventory_file=$1
+  local expected_test=$2
+  awk -v expected="$expected_test" '
+    {
+      discovered = $0
+      sub(/^[[:space:]]*Test[[:space:]]+#[0-9]+:[[:space:]]+/, "", discovered)
+      if (discovered == expected) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "$inventory_file"
+}
+
+# @brief Require a durable runner file and exact CTest registration to agree.
+# @param $1 Path to the captured ctest -N inventory.
+# @param $2 Exact CTest name.
+# @param $3 Repository runner file implementing that test.
+# @return Zero when both are present or both are absent, otherwise nonzero.
+# @throws Nothing; mismatches return nonzero with a diagnostic.
+# @note This prevents both normal and local-image workflows from silently
+#   dropping a smoke test whose source still exists.
+require_ctest_runner_pair() {
+  local inventory_file=$1
+  local test_name=$2
+  local runner_file=$3
+  local has_test=false
+  local has_runner=false
+  if ctest_inventory_has_exact_test "$inventory_file" "$test_name"; then
+    has_test=true
+  fi
+  if [[ -f "$runner_file" ]]; then
+    has_runner=true
+  fi
+  if [[ "$has_test" == "$has_runner" ]]; then
+    return 0
+  fi
+  echo "CTest/runner mismatch for $test_name: $runner_file" >&2
+  return 1
+}
+
+# @brief Require the downloaded CMake tree to match the requested CI profile.
+# @return Zero for an exact reusable build, otherwise nonzero with a diagnostic.
+# @throws Nothing; invalid state returns nonzero.
+# @note Reuse mode is fail-closed so test jobs never replace a missing or
+#   mismatched artifact by compiling on the test runner.
+require_ci_reusable_build() {
+  if ci_build_is_reusable; then
+    return 0
+  fi
+  echo "Reusable '$CI_BUILD_PROFILE' build is invalid at $BUILD_DIR." >&2
+  return 1
+}
+
+# @brief Configure a build tree or record strict reuse of its configuration.
+# @param $1 Log step name.
+# @return Zero on configuration/reuse success, otherwise nonzero.
+# @throws Nothing; command failures are returned to the caller.
+# @note CI_REUSE_BUILD=ON never falls back to configuring on a test runner.
 ensure_ci_configured() {
   local name=$1
-  if ci_reuse_build_enabled && ci_build_is_reusable; then
+  if ci_reuse_build_enabled; then
+    require_ci_reusable_build || return
     log_reused_step "$name" "Reusing prebuilt CMake tree at $BUILD_DIR."
     return
   fi
   run_logged "$name" configure_ci_build
 }
 
+# @brief Build selected targets or record strict reuse of prebuilt targets.
+# @param $1 Log step name.
+# @param $@ Remaining arguments are exact CMake target names.
+# @return Zero on build/reuse success, otherwise nonzero.
+# @throws Nothing; command failures are returned to the caller.
+# @note A reusable stamp represents targets completed by build-integrity.
 ensure_ci_targets() {
   local name=$1
   shift
-  if ci_reuse_build_enabled && ci_build_is_reusable; then
+  if ci_reuse_build_enabled; then
+    require_ci_reusable_build || return
     log_reused_step "$name" "Reusing prebuilt targets from $BUILD_DIR."
     return
   fi
   run_logged "$name" build_ci_targets "$@"
 }
 
+# @brief Build the complete tree or record strict reuse of the complete tree.
+# @param $1 Log step name.
+# @return Zero on build/reuse success, otherwise nonzero.
+# @throws Nothing; command failures are returned to the caller.
+# @note CI_REUSE_BUILD=ON requires an exact profile artifact.
 ensure_ci_all() {
   local name=$1
-  if ci_reuse_build_enabled && ci_build_is_reusable; then
+  if ci_reuse_build_enabled; then
+    require_ci_reusable_build || return
     log_reused_step "$name" "Reusing prebuilt full build from $BUILD_DIR."
     return
   fi

--- a/ci/scripts/ctest_full.sh
+++ b/ci/scripts/ctest_full.sh
@@ -10,7 +10,7 @@ cd "$REPO_ROOT"
 
 ensure_ci_configured cmake_configure
 ensure_ci_all build_all
-CTEST_EXCLUDE_REGEX=${CTEST_EXCLUDE_REGEX:-"^SplitComputeServiceRuntimeTrace$"}
+CTEST_EXCLUDE_REGEX=${CTEST_EXCLUDE_REGEX-"^(SplitComputeServiceRuntimeTrace|StaticProductConsumerSmoke|IpcDisabledInstallSmoke)$"}
 if [[ -n "$CTEST_EXCLUDE_REGEX" ]]; then
   run_logged ctest_full ctest --output-on-failure --test-dir "$BUILD_DIR" -E "$CTEST_EXCLUDE_REGEX"
 else

--- a/ci/scripts/integration_plan.sh
+++ b/ci/scripts/integration_plan.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/../.." && pwd)
+BUILD_DIR=${BUILD_DIR:-"$REPO_ROOT/build/ci-plan"}
+CI_BUILD_PROFILE=default
+BUILD_TESTING=ON
+unset PHOTOSPIDER_BUILD_IPC
+# shellcheck source=ci/scripts/common.sh
+source "$SCRIPT_DIR/common.sh"
+
+cd "$REPO_ROOT"
+
+run_logged cmake_configure configure_ci_build
+run_logged validate_profile_cache require_ci_profile_cache
+run_logged ctest_discovery ctest -N --test-dir "$BUILD_DIR"
+
+inventory_file="$CI_ARTIFACT_DIR/ctest_discovery.log"
+has_static_product_consumer_smoke=false
+has_ipc_disabled_install_smoke=false
+
+if ctest_inventory_has_exact_test \
+  "$inventory_file" StaticProductConsumerSmoke; then
+  has_static_product_consumer_smoke=true
+fi
+if ctest_inventory_has_exact_test \
+  "$inventory_file" IpcDisabledInstallSmoke; then
+  has_ipc_disabled_install_smoke=true
+fi
+
+static_runner="$REPO_ROOT/tests/integration/static_product_consumer_smoke.py"
+ipc_disabled_runner="$REPO_ROOT/tests/integration/ipc_disabled_install_smoke.py"
+require_ctest_runner_pair \
+  "$inventory_file" StaticProductConsumerSmoke "$static_runner"
+require_ctest_runner_pair \
+  "$inventory_file" IpcDisabledInstallSmoke "$ipc_disabled_runner"
+
+# @brief Persist one planner value to logs and the GitHub output channel.
+# @param $1 Stable output key consumed by the workflow.
+# @param $2 Single-line output value.
+# @return The first failed write status, or zero.
+# @throws Nothing; write failures terminate through set -e.
+# @note Local callers without GITHUB_OUTPUT still receive outputs.log.
+emit_output() {
+  local key=$1
+  local value=$2
+  printf '%s=%s\n' "$key" "$value" |
+    tee -a "$CI_ARTIFACT_DIR/outputs.log"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+: > "$CI_ARTIFACT_DIR/outputs.log"
+emit_output has_static_product_consumer_smoke \
+  "$has_static_product_consumer_smoke"
+emit_output has_ipc_disabled_install_smoke \
+  "$has_ipc_disabled_install_smoke"

--- a/ci/scripts/integration_suite.sh
+++ b/ci/scripts/integration_suite.sh
@@ -9,19 +9,77 @@ source "$SCRIPT_DIR/common.sh"
 cd "$REPO_ROOT"
 
 CI_ARTIFACT_ROOT=${CI_ARTIFACT_ROOT:-"$REPO_ROOT/CI-results"}
+DEFAULT_BUILD_DIR=$BUILD_DIR
+DEFAULT_DISCOVERY_LOG="$CI_ARTIFACT_ROOT/build-integrity/ctest_discovery.log"
+STATIC_SMOKE_RUNNER="$REPO_ROOT/tests/integration/static_product_consumer_smoke.py"
+IPC_DISABLED_SMOKE_RUNNER="$REPO_ROOT/tests/integration/ipc_disabled_install_smoke.py"
+suite_status=0
 
-CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/build-integrity" \
+# @brief Run one independent integration shard and retain aggregate failure.
+# @param $@ Command and arguments for the shard.
+# @return Zero so later independent shards still run.
+# @throws Nothing; child failure is stored in suite_status.
+# @note suite_status preserves failure for the script's final exit status.
+run_integration_check() {
+  if ! "$@"; then
+    suite_status=1
+  fi
+}
+
+CI_BUILD_PROFILE=default BUILD_TESTING=ON BUILD_DIR="$DEFAULT_BUILD_DIR" \
+  CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/build-integrity" \
   bash "$SCRIPT_DIR/build_integrity.sh"
-CI_REUSE_BUILD=ON CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/ctest-full" \
+require_ctest_runner_pair \
+  "$DEFAULT_DISCOVERY_LOG" StaticProductConsumerSmoke "$STATIC_SMOKE_RUNNER"
+require_ctest_runner_pair \
+  "$DEFAULT_DISCOVERY_LOG" IpcDisabledInstallSmoke \
+  "$IPC_DISABLED_SMOKE_RUNNER"
+run_integration_check env \
+  CI_BUILD_PROFILE=default BUILD_DIR="$DEFAULT_BUILD_DIR" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/ctest-full" \
   bash "$SCRIPT_DIR/ctest_full.sh"
-CI_REUSE_BUILD=ON CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/graph-cli" \
+if ctest_inventory_has_exact_test \
+  "$DEFAULT_DISCOVERY_LOG" StaticProductConsumerSmoke; then
+  run_integration_check env \
+    CI_BUILD_PROFILE=default BUILD_DIR="$DEFAULT_BUILD_DIR" CI_REUSE_BUILD=ON \
+    SMOKE_TEST=static-product-consumer \
+    CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/static-product-consumer-smoke" \
+    bash "$SCRIPT_DIR/build_smoke_test.sh"
+fi
+if ctest_inventory_has_exact_test \
+  "$DEFAULT_DISCOVERY_LOG" IpcDisabledInstallSmoke; then
+  IPC_DISABLED_BUILD_DIR=${IPC_DISABLED_BUILD_DIR:-"$REPO_ROOT/build/ci-ipc-disabled"}
+  if env \
+    CI_BUILD_PROFILE=ipc-disabled BUILD_TESTING=OFF \
+      PHOTOSPIDER_BUILD_IPC=OFF BUILD_DIR="$IPC_DISABLED_BUILD_DIR" \
+      CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/build-integrity-ipc-disabled" \
+      bash "$SCRIPT_DIR/build_integrity.sh"; then
+    run_integration_check env \
+      CI_BUILD_PROFILE=ipc-disabled BUILD_DIR="$IPC_DISABLED_BUILD_DIR" \
+      CI_REUSE_BUILD=ON SMOKE_TEST=ipc-disabled-install \
+      CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/ipc-disabled-install-smoke" \
+      bash "$SCRIPT_DIR/build_smoke_test.sh"
+  else
+    suite_status=1
+  fi
+fi
+run_integration_check env \
+  CI_BUILD_PROFILE=default BUILD_DIR="$DEFAULT_BUILD_DIR" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/graph-cli" \
   bash "$SCRIPT_DIR/graph_cli_script_test.sh"
-CI_REUSE_BUILD=ON CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/propagation" \
+run_integration_check env \
+  CI_BUILD_PROFILE=default BUILD_DIR="$DEFAULT_BUILD_DIR" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/propagation" \
   bash "$SCRIPT_DIR/propagation_script_test.sh"
-CI_REUSE_BUILD=ON CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/plugin-load" \
+run_integration_check env \
+  CI_BUILD_PROFILE=default BUILD_DIR="$DEFAULT_BUILD_DIR" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/plugin-load" \
   bash "$SCRIPT_DIR/plugin_load_test.sh"
-CI_REUSE_BUILD=ON \
+run_integration_check env \
+  CI_BUILD_PROFILE=default BUILD_DIR="$DEFAULT_BUILD_DIR" CI_REUSE_BUILD=ON \
   CI_ARTIFACT_DIR="$CI_ARTIFACT_ROOT/scheduler-repeat" \
   SCHEDULER_REPEAT="${SCHEDULER_REPEAT:-5}" \
   GPU_PIPELINE_REPEAT="${GPU_PIPELINE_REPEAT:-3}" \
   bash "$SCRIPT_DIR/scheduler_repeat_test.sh"
+
+exit "$suite_status"

--- a/docs/CI/github-actions.md
+++ b/docs/CI/github-actions.md
@@ -3,7 +3,7 @@
 ## Workflows
 
 - `.github/workflows/ci-healthcheck.yml`: static healthcheck on pull requests targeting `main` through `pull_request_target`, pushes to `main` and `CI/**`, and manual dispatch.
-- `.github/workflows/ci-integration.yml`: build integrity, mainline CTest, scripted `graph_cli`, scripted propagation, plugin loading, and scheduler repeat checks.
+- `.github/workflows/ci-integration.yml`: dynamic integration planning, parallel build-integrity profiles, separately sharded full CTest and build smoke tests, scripted `graph_cli`, scripted propagation, plugin loading, and scheduler repeat checks.
 - `.github/workflows/ci-sanitizer.yml`: manual ASan or TSan focused checks.
 - `.github/workflows/build-ci-image.yml`: GHCR image publish for `ghcr.io/<owner>/<repo>/photospider-ci` on image-input pushes and manual dispatch.
 
@@ -39,13 +39,30 @@ clang-format is the only tool version aligned by this change. This is not a
 version-detection gate and adds no dedicated CI job or new Ubuntu/CMake version
 lock; the existing Ubuntu base and apt-provided CMake setup remain unchanged.
 
+## Integration Test Sharding
+
+For the normal published-image path, `integration-plan` configures the checked-out commit with testing enabled and uses `ctest -N` to discover the exact `StaticProductConsumerSmoke` and `IpcDisabledInstallSmoke` test names. It enables each smoke and its required build only when that test exists. The current `main` tree therefore schedules only `build-integrity-default`, while a refactor commit that introduces the IPC-disabled install smoke also schedules `build-integrity-ipc-disabled`. This is capability discovery from the tested commit, not a hard-coded branch-name check, so the workflow definition based on `main` can also test the refactor pull request head. If a smoke runner exists without its exact CTest registration, planning fails instead of silently dropping coverage.
+
+Each profile has an independent build job that configures and compiles only that profile, then uploads a separate reusable build artifact: `ci-build-default` or `ci-build-ipc-disabled`. The IPC-disabled profile configures the producer with `PHOTOSPIDER_BUILD_IPC=OFF`. Default consumers depend only on `build-integrity-default`, while the IPC-disabled smoke depends only on `build-integrity-ipc-disabled`; a failure in one profile therefore does not suppress tests for the other profile.
+
+The test jobs reuse those prebuilt producers rather than recompiling every configuration on one runner:
+
+- `full-ctest`, `scripted-cli`, `propagation-script`, `plugin-load`, and `scheduler-repeat` download only `ci-build-default`.
+- `full-ctest` excludes `SplitComputeServiceRuntimeTrace`, `StaticProductConsumerSmoke`, and `IpcDisabledInstallSmoke`. The split trace remains outside primary CI, and the two long build smoke tests run in their own jobs.
+- `static-product-consumer-smoke` downloads `ci-build-default` and runs only `StaticProductConsumerSmoke`.
+- `ipc-disabled-install-smoke` downloads the precompiled `ci-build-ipc-disabled` producer and runs only `IpcDisabledInstallSmoke`.
+
+If CI image inputs change, the workflow cannot use the previously published image and instead runs `local-image-integration` on one Docker-capable runner. After building `photospider-ci:local`, `integration_suite.sh` performs the same dynamic plan, builds each discovered profile, and runs the same full-CTest, build-smoke, CLI, propagation, plugin, and scheduler shards sequentially with their corresponding build. This fallback preserves test selection and producer configuration while accepting that a single local-image runner cannot fan out into artifact-consuming jobs.
+
 ## Scripts
 
 - `ci/scripts/healthcheck.sh`: runs `git diff --check`, `clang-format --dry-run --Werror`, and `cpplint` on changed C++ files.
 - `ci/scripts/ci_image_changed.sh`: detects whether the current diff changes CI image inputs.
-- `ci/scripts/integration_suite.sh`: runs the integration checks sequentially for the local-image fallback path.
-- `ci/scripts/build_integrity.sh`: configures CMake, explicitly builds `graph_cli`, `test_propagation`, test plugins, scheduler plugins, then runs `ctest -N`.
-- `ci/scripts/ctest_full.sh`: builds all targets and runs CTest. It excludes `SplitComputeServiceRuntimeTrace` by default because that test writes personal-overlay evidence under `tests/results/`.
+- `ci/scripts/integration_plan.sh`: configures a small testing-enabled planning tree, discovers the two exact build-smoke test names with `ctest -N`, validates registration against the runner files, and emits smoke/build capability flags.
+- `ci/scripts/integration_suite.sh`: applies the dynamic plan and runs the resulting integration shards sequentially for the local-image fallback path.
+- `ci/scripts/build_integrity.sh`: builds the profile selected by `CI_BUILD_PROFILE`. `default` builds the required targets and the complete tree before CTest discovery; `ipc-disabled` sets `BUILD_TESTING=OFF` and `PHOTOSPIDER_BUILD_IPC=OFF`, validates the cache, and builds only the `photospider` producer target.
+- `ci/scripts/ctest_full.sh`: reuses or builds the default producer and runs CTest, excluding `SplitComputeServiceRuntimeTrace` and the two separately sharded build smoke tests by default.
+- `ci/scripts/build_smoke_test.sh`: runs one separately selected build smoke test from a reusable producer; set `SMOKE_TEST` to `static-product-consumer` or `ipc-disabled-install`.
 - `ci/scripts/graph_cli_script_test.sh`: runs positive and negative scripted REPL checks.
 - `ci/scripts/propagation_script_test.sh`: builds `test_propagation` and runs `tiles all` on linear and complex propagation graphs.
 - `ci/scripts/plugin_load_test.sh`: checks plugin artifacts, plugin manager tests, scheduler plugin loader tests, and CLI scheduler plugin listing.
@@ -56,13 +73,44 @@ lock; the existing Ubuntu base and apt-provided CMake setup remain unchanged.
 
 ```bash
 CI_ARTIFACT_DIR=CI-results/healthcheck bash ci/scripts/healthcheck.sh
-CI_ARTIFACT_DIR=CI-results/build-integrity bash ci/scripts/build_integrity.sh
-CI_ARTIFACT_DIR=CI-results/ctest-full bash ci/scripts/ctest_full.sh
-CI_ARTIFACT_DIR=CI-results/graph-cli bash ci/scripts/graph_cli_script_test.sh
-CI_ARTIFACT_DIR=CI-results/propagation bash ci/scripts/propagation_script_test.sh
-CI_ARTIFACT_DIR=CI-results/plugin-load bash ci/scripts/plugin_load_test.sh
-CI_ARTIFACT_DIR=CI-results/scheduler-repeat bash ci/scripts/scheduler_repeat_test.sh
+GITHUB_OUTPUT=/tmp/photospider-integration-plan.out \
+  CI_ARTIFACT_DIR=CI-results/integration-plan \
+  bash ci/scripts/integration_plan.sh
+BUILD_DIR="$PWD/build/ci-default" CI_BUILD_PROFILE=default \
+  CI_ARTIFACT_DIR=CI-results/build-integrity-default \
+  bash ci/scripts/build_integrity.sh
+BUILD_DIR="$PWD/build/ci-ipc-disabled" CI_BUILD_PROFILE=ipc-disabled \
+  CI_ARTIFACT_DIR=CI-results/build-integrity-ipc-disabled \
+  bash ci/scripts/build_integrity.sh
+BUILD_DIR="$PWD/build/ci-default" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR=CI-results/ctest-full bash ci/scripts/ctest_full.sh
+BUILD_DIR="$PWD/build/ci-default" CI_REUSE_BUILD=ON \
+  SMOKE_TEST=static-product-consumer \
+  CI_ARTIFACT_DIR=CI-results/static-product-consumer-smoke \
+  bash ci/scripts/build_smoke_test.sh
+BUILD_DIR="$PWD/build/ci-ipc-disabled" CI_REUSE_BUILD=ON \
+  SMOKE_TEST=ipc-disabled-install \
+  CI_ARTIFACT_DIR=CI-results/ipc-disabled-install-smoke \
+  bash ci/scripts/build_smoke_test.sh
+BUILD_DIR="$PWD/build/ci-default" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR=CI-results/graph-cli \
+  bash ci/scripts/graph_cli_script_test.sh
+BUILD_DIR="$PWD/build/ci-default" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR=CI-results/propagation \
+  bash ci/scripts/propagation_script_test.sh
+BUILD_DIR="$PWD/build/ci-default" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR=CI-results/plugin-load \
+  bash ci/scripts/plugin_load_test.sh
+BUILD_DIR="$PWD/build/ci-default" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR=CI-results/scheduler-repeat \
+  bash ci/scripts/scheduler_repeat_test.sh
 SANITIZER=asan CI_ARTIFACT_DIR=CI-results/sanitizer-asan bash ci/scripts/sanitizer_test.sh
+```
+
+The `ipc-disabled` profile and either smoke command are valid only when the checked-out commit's integration plan reports them. To reproduce the entire dynamically selected sequence, use:
+
+```bash
+CI_ARTIFACT_ROOT=CI-results bash ci/scripts/integration_suite.sh
 ```
 
 Docker reproduction:

--- a/docs/CI/zh/github-actions.zh.md
+++ b/docs/CI/zh/github-actions.zh.md
@@ -3,7 +3,7 @@
 ## Workflow
 
 - `.github/workflows/ci-healthcheck.yml`：通过 `pull_request_target` 处理目标为 `main` 的 pull request，并在推送到 `main` 和 `CI/**`、手动触发时运行静态 healthcheck。
-- `.github/workflows/ci-integration.yml`：运行构建完整性、主线 CTest、`graph_cli` 脚本测试、propagation 脚本测试、插件加载测试和 scheduler 重复测试。
+- `.github/workflows/ci-integration.yml`：运行动态 integration 规划、并行 build-integrity profile、独立分片的完整 CTest 与 build smoke 测试、`graph_cli` 脚本测试、propagation 脚本测试、插件加载测试和 scheduler 重复测试。
 - `.github/workflows/ci-sanitizer.yml`：手动运行 ASan 或 TSan 聚焦检查。
 - `.github/workflows/build-ci-image.yml`：在镜像输入相关 push 和手动触发时发布 GHCR 镜像 `ghcr.io/<owner>/<repo>/photospider-ci`。
 
@@ -36,13 +36,30 @@ nlohmann-json、Python、cpplint 和 clang-format。Formatter 通过 PyPI wheel 
 本次改动只对齐 clang-format 工具版本。这不是版本检测门禁，不会新增专用 CI job，也不会新增
 Ubuntu/CMake 版本锁定；既有 Ubuntu base 与 apt 提供的 CMake 设置保持不变。
 
+## Integration 测试分片
+
+对常规 published-image 路径，`integration-plan` 会启用测试来配置被 checkout 的 commit，并使用 `ctest -N` 精确发现 `StaticProductConsumerSmoke` 和 `IpcDisabledInstallSmoke` 测试名。它仅在对应测试存在时启用各 smoke 及其所需 build。因此，当前 `main` 树只调度 `build-integrity-default`；引入 IPC-disabled install smoke 的 refactor commit 还会调度 `build-integrity-ipc-disabled`。这是针对被测 commit 的能力发现，而不是硬编码的分支名判断，因此以 `main` 为基础的 workflow 定义也能测试 refactor pull request 的 head。如果 smoke runner 已存在却没有对应的精确 CTest 注册，规划会失败，不会静默丢失覆盖。
+
+每个 profile 都有独立 build job，只配置和编译该 profile，再上传独立的可复用构建 artifact：`ci-build-default` 或 `ci-build-ipc-disabled`。IPC-disabled profile 使用 `PHOTOSPIDER_BUILD_IPC=OFF` 配置 producer。Default consumers 只依赖 `build-integrity-default`，IPC-disabled smoke 只依赖 `build-integrity-ipc-disabled`；因此，一个 profile 失败不会抑制另一个 profile 的测试。
+
+测试 job 会复用这些预构建 producer，不再由一个 runner 重新编译全部配置：
+
+- `full-ctest`、`scripted-cli`、`propagation-script`、`plugin-load` 和 `scheduler-repeat` 只下载 `ci-build-default`。
+- `full-ctest` 排除 `SplitComputeServiceRuntimeTrace`、`StaticProductConsumerSmoke` 和 `IpcDisabledInstallSmoke`。split trace 继续置于主 CI 之外，两个耗时较长的 build smoke 测试则在各自 job 中运行。
+- `static-product-consumer-smoke` 下载 `ci-build-default`，并且只运行 `StaticProductConsumerSmoke`。
+- `ipc-disabled-install-smoke` 下载预编译的 `ci-build-ipc-disabled` producer，并且只运行 `IpcDisabledInstallSmoke`。
+
+如果 CI 镜像输入发生变化，workflow 不能使用此前发布的镜像，而会在一个具备 Docker 能力的 runner 上运行 `local-image-integration`。构建 `photospider-ci:local` 后，`integration_suite.sh` 会执行同样的动态规划，构建发现到的每个 profile，再使用各自对应的 build，依次运行相同的完整 CTest、build smoke、CLI、propagation、plugin 和 scheduler 分片。该 fallback 保持相同的测试选择与 producer 配置，但接受单个本地镜像 runner 无法将工作扇出到多个 artifact-consuming job 的限制。
+
 ## 脚本
 
 - `ci/scripts/healthcheck.sh`：对改动的 C++ 文件运行 `git diff --check`、`clang-format --dry-run --Werror` 和 `cpplint`。
 - `ci/scripts/ci_image_changed.sh`：检测当前 diff 是否修改 CI 镜像输入。
-- `ci/scripts/integration_suite.sh`：为本地镜像 fallback 路径顺序运行 integration 检查。
-- `ci/scripts/build_integrity.sh`：配置 CMake，显式构建 `graph_cli`、`test_propagation`、测试插件和 scheduler 插件，然后运行 `ctest -N`。
-- `ci/scripts/ctest_full.sh`：构建全部目标并运行 CTest。默认排除 `SplitComputeServiceRuntimeTrace`，因为该测试会向 personal overlay 的 `tests/results/` 写证据。
+- `ci/scripts/integration_plan.sh`：配置一个启用测试的小型规划 build tree，使用 `ctest -N` 发现两个精确 build-smoke 测试名，对照 runner 文件校验注册，并输出 smoke/build 能力标记。
+- `ci/scripts/integration_suite.sh`：应用动态规划，并为本地镜像 fallback 路径顺序运行所得 integration 分片。
+- `ci/scripts/build_integrity.sh`：构建 `CI_BUILD_PROFILE` 选定的 profile。`default` 会构建 required targets 与完整 build tree，再执行 CTest discovery；`ipc-disabled` 设置 `BUILD_TESTING=OFF` 与 `PHOTOSPIDER_BUILD_IPC=OFF`，校验 cache，并且只构建 `photospider` producer target。
+- `ci/scripts/ctest_full.sh`：复用或构建 default producer 并运行 CTest，默认排除 `SplitComputeServiceRuntimeTrace` 和两个已独立分片的 build smoke 测试。
+- `ci/scripts/build_smoke_test.sh`：从可复用 producer 运行一个单独选择的 build smoke 测试；将 `SMOKE_TEST` 设置为 `static-product-consumer` 或 `ipc-disabled-install`。
 - `ci/scripts/graph_cli_script_test.sh`：运行正路径和负路径 REPL 脚本检查。
 - `ci/scripts/propagation_script_test.sh`：构建 `test_propagation`，并对线性和复杂 propagation 图运行 `tiles all`。
 - `ci/scripts/plugin_load_test.sh`：检查插件产物、plugin manager 测试、scheduler plugin loader 测试和 CLI scheduler 插件列表。
@@ -53,13 +70,44 @@ Ubuntu/CMake 版本锁定；既有 Ubuntu base 与 apt 提供的 CMake 设置保
 
 ```bash
 CI_ARTIFACT_DIR=CI-results/healthcheck bash ci/scripts/healthcheck.sh
-CI_ARTIFACT_DIR=CI-results/build-integrity bash ci/scripts/build_integrity.sh
-CI_ARTIFACT_DIR=CI-results/ctest-full bash ci/scripts/ctest_full.sh
-CI_ARTIFACT_DIR=CI-results/graph-cli bash ci/scripts/graph_cli_script_test.sh
-CI_ARTIFACT_DIR=CI-results/propagation bash ci/scripts/propagation_script_test.sh
-CI_ARTIFACT_DIR=CI-results/plugin-load bash ci/scripts/plugin_load_test.sh
-CI_ARTIFACT_DIR=CI-results/scheduler-repeat bash ci/scripts/scheduler_repeat_test.sh
+GITHUB_OUTPUT=/tmp/photospider-integration-plan.out \
+  CI_ARTIFACT_DIR=CI-results/integration-plan \
+  bash ci/scripts/integration_plan.sh
+BUILD_DIR="$PWD/build/ci-default" CI_BUILD_PROFILE=default \
+  CI_ARTIFACT_DIR=CI-results/build-integrity-default \
+  bash ci/scripts/build_integrity.sh
+BUILD_DIR="$PWD/build/ci-ipc-disabled" CI_BUILD_PROFILE=ipc-disabled \
+  CI_ARTIFACT_DIR=CI-results/build-integrity-ipc-disabled \
+  bash ci/scripts/build_integrity.sh
+BUILD_DIR="$PWD/build/ci-default" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR=CI-results/ctest-full bash ci/scripts/ctest_full.sh
+BUILD_DIR="$PWD/build/ci-default" CI_REUSE_BUILD=ON \
+  SMOKE_TEST=static-product-consumer \
+  CI_ARTIFACT_DIR=CI-results/static-product-consumer-smoke \
+  bash ci/scripts/build_smoke_test.sh
+BUILD_DIR="$PWD/build/ci-ipc-disabled" CI_REUSE_BUILD=ON \
+  SMOKE_TEST=ipc-disabled-install \
+  CI_ARTIFACT_DIR=CI-results/ipc-disabled-install-smoke \
+  bash ci/scripts/build_smoke_test.sh
+BUILD_DIR="$PWD/build/ci-default" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR=CI-results/graph-cli \
+  bash ci/scripts/graph_cli_script_test.sh
+BUILD_DIR="$PWD/build/ci-default" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR=CI-results/propagation \
+  bash ci/scripts/propagation_script_test.sh
+BUILD_DIR="$PWD/build/ci-default" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR=CI-results/plugin-load \
+  bash ci/scripts/plugin_load_test.sh
+BUILD_DIR="$PWD/build/ci-default" CI_REUSE_BUILD=ON \
+  CI_ARTIFACT_DIR=CI-results/scheduler-repeat \
+  bash ci/scripts/scheduler_repeat_test.sh
 SANITIZER=asan CI_ARTIFACT_DIR=CI-results/sanitizer-asan bash ci/scripts/sanitizer_test.sh
+```
+
+只有被 checkout commit 的 integration plan 报告了相应能力时，`ipc-disabled` profile 和对应的 smoke 命令才有效。要复现动态选出的完整执行顺序，可使用：
+
+```bash
+CI_ARTIFACT_ROOT=CI-results bash ci/scripts/integration_suite.sh
 ```
 
 Docker 复现：


### PR DESCRIPTION
## 变更摘要

- 基于被测 commit 的 CTest inventory 动态发现两个 build smoke。
- 将 default 与 IPC-disabled 配置拆成互不依赖的 build-integrity job，并分别上传匹配的构建 artifact。
- 将 StaticProductConsumerSmoke 与 IpcDisabledInstallSmoke 从 full-ctest 拆为独立 job。
- 所有测试 runner 严格下载并校验对应 profile 的预构建产物，不允许静默重新编译。
- 同步英文 CI 文档及中文镜像。

## 分支兼容性

当前 main 不包含两个 refactor-only smoke，因此只运行 default profile。refactor PR head 含对应 CTest 与 runner 后，会自动启用两个 smoke 及 IPC-disabled build，无需按分支名硬编码。

## 验证

- bash -n ci/scripts/*.sh
- Ruby YAML 解析与 workflow 依赖/timeout 语义断言
- main 基线 integration_plan.sh 实际执行
- profile cache、严格 artifact reuse、精确 CTest 名称与排除列表断言
- git diff --cached --check
- GitHub Actions run 29341529916：成功；main 仅构建 default profile，full-ctest 复用 artifact，158/158 通过

## 已知失败

本 PR 不修改或规避 refactor/codebase-refactor 当前的 SchedulerSdkExample.NewBatchWaitRetainsOldBorrowedExecutorFence 失败。该测试仍由 full-ctest 执行。