### PR TITLE
[CI] stage graph document CLI contract checks

### DIFF
--- a/ci/scripts/graph_cli_script_test.sh
+++ b/ci/scripts/graph_cli_script_test.sh
@@ -3,8 +3,15 @@
 set -Eeuo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+invocation_dir=$PWD
 # shellcheck source=ci/scripts/common.sh
 source "$SCRIPT_DIR/common.sh"
+
+# Keep documented relative artifact roots anchored to the caller before any
+# scenario enters its isolated working directory.
+if [[ "$CI_ARTIFACT_DIR" != /* ]]; then
+  CI_ARTIFACT_DIR="$invocation_dir/$CI_ARTIFACT_DIR"
+fi
 
 cd "$REPO_ROOT"
 

--- a/ci/scripts/graph_cli_script_test.sh
+++ b/ci/scripts/graph_cli_script_test.sh
@@ -8,46 +8,161 @@ source "$SCRIPT_DIR/common.sh"
 
 cd "$REPO_ROOT"
 
+graph_document_test_source="$REPO_ROOT/tests/integration/test_graph_document_errors.cpp"
+has_graph_document_test_source=false
+has_graph_document_test_target=false
+has_graph_document_test_discovery=false
+
+if [[ -f "$graph_document_test_source" ]]; then
+  has_graph_document_test_source=true
+fi
+if grep -Eq \
+  '^[[:space:]]*add_ps_test\(test_graph_document_errors([[:space:]]|$)' \
+  "$REPO_ROOT/CMakeLists.txt"; then
+  has_graph_document_test_target=true
+fi
+if grep -Eq \
+  '^[[:space:]]*gtest_discover_tests\(test_graph_document_errors([[:space:]]|$)' \
+  "$REPO_ROOT/CMakeLists.txt"; then
+  has_graph_document_test_discovery=true
+fi
+
+capability_markers="$has_graph_document_test_source:$has_graph_document_test_target"
+capability_markers+=":$has_graph_document_test_discovery"
+case "$capability_markers" in
+  false:false:false)
+    missing_source_contract=legacy_publication
+    ;;
+  true:true:true)
+    missing_source_contract=transactional_rejection
+    ;;
+  *)
+    echo "Inconsistent graph document transaction capability markers." >&2
+    echo "source=$has_graph_document_test_source" \
+      "target=$has_graph_document_test_target" \
+      "discovery=$has_graph_document_test_discovery" >&2
+    exit 1
+    ;;
+esac
+
+printf 'Graph document missing-source contract: %s\n' \
+  "$missing_source_contract" |
+  tee "$CI_ARTIFACT_DIR/capability.log"
+
 ensure_ci_configured cmake_configure
 ensure_ci_targets build_graph_cli graph_cli cpu_work_stealing_example_plugin serial_debug_example_plugin
 
-mkdir -p "$CI_ARTIFACT_DIR/cache" "$CI_ARTIFACT_DIR/sessions"
+fixture_path="$REPO_ROOT/util/testcases/propagation_linear_test.yaml"
+runtime_root=$(mktemp -d "$CI_ARTIFACT_DIR/graph_cli_runtime.XXXXXX")
+trap 'rm -rf -- "$runtime_root"' EXIT
+
+positive_runtime="$runtime_root/positive"
+missing_source_runtime="$runtime_root/missing-source"
+invalid_target_runtime="$runtime_root/invalid-target"
+mkdir -p "$CI_ARTIFACT_DIR/cache" \
+  "$positive_runtime/home" \
+  "$missing_source_runtime/home" \
+  "$invalid_target_runtime/home"
+
 config_path="$CI_ARTIFACT_DIR/graph_cli_config.yaml"
 write_cli_config "$config_path" "$CI_ARTIFACT_DIR/cache"
 
 positive_script="$CI_ARTIFACT_DIR/graph_cli_positive.repl"
 cat > "$positive_script" <<EOF
-load ci_graph util/testcases/propagation_linear_test.yaml
+load ci_graph $fixture_path
 compute all parallel nosave m
 traversal
 exit
 EOF
 
 positive_log="$CI_ARTIFACT_DIR/graph_cli_positive.log"
-printf 'source %s\n' "$positive_script" |
-  "$BUILD_DIR/bin/graph_cli" --config "$config_path" --repl \
-    > "$positive_log" 2>&1
+(
+  cd "$positive_runtime"
+  printf 'source %s\n' "$positive_script" |
+    HOME="$positive_runtime/home" \
+      "$BUILD_DIR/bin/graph_cli" --config "$config_path" --repl \
+      > "$positive_log" 2>&1
+)
 
 require_grep "Loaded session 'ci_graph'" "$positive_log"
 require_grep "Computation finished" "$positive_log"
 require_grep "Post-order|Dependency Tree" "$positive_log"
 
-negative_script="$CI_ARTIFACT_DIR/graph_cli_negative.repl"
-cat > "$negative_script" <<EOF
+# Run missing-source publication independently from invalid target parsing so
+# each revision has one explicit, capability-selected contract.
+missing_source_script="$CI_ARTIFACT_DIR/graph_cli_missing_source.repl"
+cat > "$missing_source_script" <<EOF
 load ci_missing does/not/exist.yaml
+graphs
+compute all
+exit
+EOF
+
+missing_source_log="$CI_ARTIFACT_DIR/graph_cli_missing_source.log"
+(
+  cd "$missing_source_runtime"
+  printf 'source %s\n' "$missing_source_script" |
+    HOME="$missing_source_runtime/home" \
+      "$BUILD_DIR/bin/graph_cli" --config "$config_path" --repl \
+      > "$missing_source_log" 2>&1
+)
+
+case "$missing_source_contract" in
+  legacy_publication)
+    require_grep \
+      "Warning: source YAML file not found for graph 'ci_missing'" \
+      "$missing_source_log"
+    require_grep "Loaded session 'ci_missing'" "$missing_source_log"
+    require_grep "Loaded graphs:" "$missing_source_log"
+    require_grep "  - ci_missing  \\[current\\]" "$missing_source_log"
+    require_grep "No ending nodes to compute in the graph[.]" \
+      "$missing_source_log"
+    if grep -Fq "Error: failed to load session 'ci_missing'" \
+      "$missing_source_log" ||
+      grep -Fq "(no graphs loaded)" "$missing_source_log" ||
+      grep -Fq "No current graph. Use load/switch." "$missing_source_log"; then
+      echo "Legacy missing-source behavior matched transactional output." >&2
+      exit 1
+    fi
+    ;;
+  transactional_rejection)
+    require_grep \
+      "Error: failed to load session 'ci_missing' from 'does/not/exist[.]yaml'[.]" \
+      "$missing_source_log"
+    require_grep "[(]no graphs loaded[)]" "$missing_source_log"
+    require_grep "No current graph[.] Use load/switch[.]" \
+      "$missing_source_log"
+    if grep -Fq "Warning: source YAML file not found for graph 'ci_missing'" \
+      "$missing_source_log" ||
+      grep -Fq "Loaded session 'ci_missing'" "$missing_source_log" ||
+      grep -Fq "Loaded graphs:" "$missing_source_log"; then
+      echo "Transactional missing-source behavior published legacy state." >&2
+      exit 1
+    fi
+    ;;
+esac
+
+invalid_target_script="$CI_ARTIFACT_DIR/graph_cli_invalid_target.repl"
+cat > "$invalid_target_script" <<EOF
+load ci_invalid_target $fixture_path
 compute nope
 unknown-ci-command
 exit
 EOF
 
-negative_log="$CI_ARTIFACT_DIR/graph_cli_negative.log"
-printf 'source %s\n' "$negative_script" |
-  "$BUILD_DIR/bin/graph_cli" --config "$config_path" --repl \
-    > "$negative_log" 2>&1
+invalid_target_log="$CI_ARTIFACT_DIR/graph_cli_invalid_target.log"
+(
+  cd "$invalid_target_runtime"
+  printf 'source %s\n' "$invalid_target_script" |
+    HOME="$invalid_target_runtime/home" \
+      "$BUILD_DIR/bin/graph_cli" --config "$config_path" --repl \
+      > "$invalid_target_log" 2>&1
+)
 
-require_grep "Warning: source YAML file not found for graph 'ci_missing'" "$negative_log"
-require_grep "Invalid target 'nope'" "$negative_log"
-require_grep "Unknown command: unknown-ci-command" "$negative_log"
+require_grep "Loaded session 'ci_invalid_target'" "$invalid_target_log"
+require_grep "Invalid target 'nope'" "$invalid_target_log"
+require_grep "Unknown command: unknown-ci-command" "$invalid_target_log"
 
-echo "graph_cli positive and negative scripted checks passed." |
+echo "graph_cli positive, $missing_source_contract missing-source," \
+  "and invalid-target checks passed." |
   tee "$CI_ARTIFACT_DIR/summary.log"

--- a/ci/scripts/graph_cli_script_test.sh
+++ b/ci/scripts/graph_cli_script_test.sh
@@ -54,7 +54,20 @@ ensure_ci_targets build_graph_cli graph_cli cpu_work_stealing_example_plugin ser
 
 fixture_path="$REPO_ROOT/util/testcases/propagation_linear_test.yaml"
 runtime_root=$(mktemp -d "$CI_ARTIFACT_DIR/graph_cli_runtime.XXXXXX")
-trap 'rm -rf -- "$runtime_root"' EXIT
+
+# Preserve failed runtimes inside the uploaded artifact tree while removing
+# successful scratch state.
+cleanup_runtime() {
+  local status=$?
+  trap - EXIT
+  if ((status == 0)); then
+    rm -rf -- "$runtime_root"
+  else
+    echo "Preserving failed graph_cli runtime: $runtime_root" >&2
+  fi
+  exit "$status"
+}
+trap cleanup_runtime EXIT
 
 positive_runtime="$runtime_root/positive"
 missing_source_runtime="$runtime_root/missing-source"

--- a/docs/CI/github-actions.md
+++ b/docs/CI/github-actions.md
@@ -54,6 +54,42 @@ The test jobs reuse those prebuilt producers rather than recompiling every confi
 
 If CI image inputs change, the workflow cannot use the previously published image and instead runs `local-image-integration` on one Docker-capable runner. After building `photospider-ci:local`, `integration_suite.sh` performs the same dynamic plan, builds each discovered profile, and runs the same full-CTest, build-smoke, CLI, propagation, plugin, and scheduler shards sequentially with their corresponding build. This fallback preserves test selection and producer configuration while accepting that a single local-image runner cannot fan out into artifact-consuming jobs.
 
+## Scripted CLI Capability Transition
+
+`graph_cli_script_test.sh` selects the explicit-missing-source contract before
+it starts any `graph_cli` process. The stable capability marker is the complete
+long-lived Graph document error regression registration: the
+`tests/integration/test_graph_document_errors.cpp` source, its
+`add_ps_test(test_graph_document_errors ...)` target, and its
+`gtest_discover_tests(test_graph_document_errors ...)` registration must all be
+present. If all three are absent, the tested revision has the legacy
+missing-source publication contract. If all three are present, it has the
+transactional rejection contract. A partial marker is an inconsistent test
+inventory and fails the script.
+
+The marker is evaluated from the checked-out revision, not from a branch name,
+commit identity, or observed CLI output. The legacy path therefore positively
+requires the warning, published session, current-graph listing, and empty-graph
+compute result while rejecting transactional output. The transactional path
+requires the classified load failure, empty graph inventory, and absent current
+graph while rejecting the legacy warning and publication. Invalid-target
+parsing is checked in a separate runtime after loading a maintained fixture, so
+it never relies on either missing-source state.
+
+This is a two-stage protected-path transition. First, the `CI/**` change lands
+on `main`, where the complete marker is absent and the legacy contract is
+verified. Then the architecture pull request must incorporate this same script
+unchanged and remove its independent `ci/**` delta; its complete Graph document
+error registration selects the transactional contract. Until that second step,
+the protected-path guard correctly continues to reject the architecture pull
+request's CI-file delta.
+
+After the transactional Graph document contract is present on `main` and every
+active pull-request or maintained branch head tested by this protected script
+contains the complete registration, a follow-up `CI/**` change must remove the
+legacy path and capability switch. The script should then assert transactional
+rejection unconditionally.
+
 ## Scripts
 
 - `ci/scripts/healthcheck.sh`: runs `git diff --check`, `clang-format --dry-run --Werror`, and `cpplint` on changed C++ files.
@@ -63,7 +99,7 @@ If CI image inputs change, the workflow cannot use the previously published imag
 - `ci/scripts/build_integrity.sh`: builds the profile selected by `CI_BUILD_PROFILE`. `default` builds the required targets and the complete tree before CTest discovery; `ipc-disabled` sets `BUILD_TESTING=OFF` and `PHOTOSPIDER_BUILD_IPC=OFF`, validates the cache, and builds only the `photospider` producer target.
 - `ci/scripts/ctest_full.sh`: reuses or builds the default producer and runs CTest, excluding `SplitComputeServiceRuntimeTrace` and the two separately sharded build smoke tests by default.
 - `ci/scripts/build_smoke_test.sh`: runs one separately selected build smoke test from a reusable producer; set `SMOKE_TEST` to `static-product-consumer` or `ipc-disabled-install`.
-- `ci/scripts/graph_cli_script_test.sh`: runs positive and negative scripted REPL checks.
+- `ci/scripts/graph_cli_script_test.sh`: runs isolated positive, explicit-missing-source, and invalid-target REPL checks using the pre-execution Graph document capability marker described above.
 - `ci/scripts/propagation_script_test.sh`: builds `test_propagation` and runs `tiles all` on linear and complex propagation graphs.
 - `ci/scripts/plugin_load_test.sh`: checks plugin artifacts, plugin manager tests, scheduler plugin loader tests, and CLI scheduler plugin listing.
 - `ci/scripts/scheduler_repeat_test.sh`: repeats key scheduler tests.

--- a/docs/CI/zh/github-actions.zh.md
+++ b/docs/CI/zh/github-actions.zh.md
@@ -51,6 +51,31 @@ Ubuntu/CMake 版本锁定；既有 Ubuntu base 与 apt 提供的 CMake 设置保
 
 如果 CI 镜像输入发生变化，workflow 不能使用此前发布的镜像，而会在一个具备 Docker 能力的 runner 上运行 `local-image-integration`。构建 `photospider-ci:local` 后，`integration_suite.sh` 会执行同样的动态规划，构建发现到的每个 profile，再使用各自对应的 build，依次运行相同的完整 CTest、build smoke、CLI、propagation、plugin 和 scheduler 分片。该 fallback 保持相同的测试选择与 producer 配置，但接受单个本地镜像 runner 无法将工作扇出到多个 artifact-consuming job 的限制。
 
+## 脚本式 CLI 能力过渡
+
+`graph_cli_script_test.sh` 会在启动任何 `graph_cli` 进程前选择“显式来源缺失”契约。稳定能力标记是
+完整的长期 Graph 文档错误回归注册：必须同时存在
+`tests/integration/test_graph_document_errors.cpp` 源文件、对应的
+`add_ps_test(test_graph_document_errors ...)` target，以及
+`gtest_discover_tests(test_graph_document_errors ...)` 注册。三者全都不存在时，被测 revision 使用旧的
+missing-source 发布契约；三者全都存在时，被测 revision 使用事务式拒绝契约；只存在一部分说明测试
+清单不一致，脚本会直接失败。
+
+能力标记来自 checkout 的 revision，不依赖分支名、commit identity 或观察到的 CLI 输出。因此，
+旧路径会正向要求 warning、已发布 session、current Graph 清单以及空 Graph compute 结果，同时拒绝
+事务路径输出；事务路径会要求分类后的 load 失败、空 Graph 清单和不存在 current Graph，同时拒绝
+旧 warning 与发布行为。无效 target 解析会在另一个隔离 runtime 中先加载维护中的 fixture，因此
+绝不依赖任一种 missing-source 状态。
+
+这是一个分两阶段完成的受保护路径过渡。第一阶段先把 `CI/**` 变更合入 `main`；此时完整标记
+不存在，脚本验证旧契约。第二阶段要求架构 pull request 原样采用同一脚本，并消除其独立的
+`ci/**` 差异；该分支完整的 Graph 文档错误注册会选择事务契约。在第二阶段完成之前，受保护路径
+门禁仍会正确拒绝架构 pull request 中的 CI 文件差异。
+
+当事务式 Graph 文档契约已经进入 `main`，并且所有由该受保护脚本测试的活跃 pull-request 或维护
+分支 head 都包含完整注册后，后续 `CI/**` 变更必须删除旧路径与能力切换。此后脚本应无条件断言
+事务式拒绝。
+
 ## 脚本
 
 - `ci/scripts/healthcheck.sh`：对改动的 C++ 文件运行 `git diff --check`、`clang-format --dry-run --Werror` 和 `cpplint`。
@@ -60,7 +85,7 @@ Ubuntu/CMake 版本锁定；既有 Ubuntu base 与 apt 提供的 CMake 设置保
 - `ci/scripts/build_integrity.sh`：构建 `CI_BUILD_PROFILE` 选定的 profile。`default` 会构建 required targets 与完整 build tree，再执行 CTest discovery；`ipc-disabled` 设置 `BUILD_TESTING=OFF` 与 `PHOTOSPIDER_BUILD_IPC=OFF`，校验 cache，并且只构建 `photospider` producer target。
 - `ci/scripts/ctest_full.sh`：复用或构建 default producer 并运行 CTest，默认排除 `SplitComputeServiceRuntimeTrace` 和两个已独立分片的 build smoke 测试。
 - `ci/scripts/build_smoke_test.sh`：从可复用 producer 运行一个单独选择的 build smoke 测试；将 `SMOKE_TEST` 设置为 `static-product-consumer` 或 `ipc-disabled-install`。
-- `ci/scripts/graph_cli_script_test.sh`：运行正路径和负路径 REPL 脚本检查。
+- `ci/scripts/graph_cli_script_test.sh`：使用上述执行前 Graph 文档能力标记，运行相互隔离的正路径、显式来源缺失和无效 target REPL 检查。
 - `ci/scripts/propagation_script_test.sh`：构建 `test_propagation`，并对线性和复杂 propagation 图运行 `tiles all`。
 - `ci/scripts/plugin_load_test.sh`：检查插件产物、plugin manager 测试、scheduler plugin loader 测试和 CLI scheduler 插件列表。
 - `ci/scripts/scheduler_repeat_test.sh`：重复运行关键 scheduler 测试。


### PR DESCRIPTION
## 变更

- 在运行 `graph_cli` 前，用长期 `test_graph_document_errors` 源文件、CMake target 与 CTest discovery 三项完整注册选择 missing-source 契约。
- `main` 三项全无时精确断言旧的 session 发布行为；PR #39 三项全有时精确断言 Issue #47 的事务式拒绝行为；部分 marker 直接失败。
- 将 positive、missing-source 与 invalid-target 场景隔离到独立 runtime，并同步更新英文 CI 权威文档与中文镜像。

## 原因与边界

这是 Issue #47 的受保护 `ci/**` 前置变更。普通 refactor 分支不能携带 CI 路径改动，因此先通过 `CI/**` 分支让同一脚本落入 `main`。随后 PR #39 必须原样采用该脚本并消除自身 `ci/**` 差异，才会由完整 marker 选择新事务语义。

关联 Issue：#47
架构 PR：#39

本 PR 不包含 PR #39 的架构产品代码，不修改 workflow，也不会自行合并。

## 本机验证

- `bash -n ci/scripts/graph_cli_script_test.sh`
- `BUILD_DIR="$PWD/build/issue47-ci-main" CI_ARTIFACT_DIR=<temp> CI_JOBS=6 bash ci/scripts/graph_cli_script_test.sh`（`legacy_publication`，通过）
- 现有 `build/issue47-final` 的 Graph document CTest inventory、三项 marker 与事务式 missing-source/invalid-target REPL 断言（通过；未重复 full build/完整 CTest）
- 中英文能力标记与两阶段边界核对（通过）
- `git diff --check origin/main...HEAD`
- `CI_BASE_REF=origin/main bash ci/scripts/healthcheck.sh`

## 最终远端验证

最终 head `20493fe4d47357bbd273658461a658c188ce4e3d`：

- CI Healthcheck run `29420679355`：success；执行的 protected-ci-paths、ci-image-change、healthcheck 全部成功，local-image 按条件跳过。
- CI Integration run `29420679892`：success；protected-ci-paths、ci-image-change、integration-plan、build-integrity-default、full-ctest、scripted-cli、propagation-script、plugin-load、scheduler-repeat 全部成功；local-image、IPC-disabled 与 main 未注册的 static smoke 按能力跳过。