### PR TITLE
fix: repair CLI Host Doxygen manual audit

### DIFF
--- a/docs/development/Testing-and-Validation.md
+++ b/docs/development/Testing-and-Validation.md
@@ -155,6 +155,17 @@ python3 tests/verification/codebase_structure/scheduler_doxygen_ast.py \
   --out /tmp/photospider-scheduler-doxygen
 ```
 
+The CLI/Host audit treats
+`apps/graph_cli/src/cli_config.cpp::apply_cli_scheduler_defaults` as the
+canonical scheduler-default definition and validates its complete Doxygen in
+that translation unit. It separately audits `run_graph_cli` and its
+resource-exhaustion policy. For `ConfigEditor::SyncUiStateToModel`, both parse
+chains must rethrow `std::bad_alloc`. Scheduler-worker validation handles
+`std::invalid_argument` specifically, while history-size `std::stoi` ignores
+its other errors through exactly one broad `catch (...)`; the catalog therefore
+expects one broad catch for that function, guarded by the preceding
+`std::bad_alloc` handler.
+
 Their files may remain in the primary repository because this document defines
 their lasting manual role. They must remain absent from CTest and GitHub CI.
 Their `--out` directories are disposable temporary working directories outside

--- a/docs/development/zh/Testing-and-Validation.zh.md
+++ b/docs/development/zh/Testing-and-Validation.zh.md
@@ -116,6 +116,14 @@ python3 tests/verification/codebase_structure/scheduler_doxygen_ast.py \
   --out /tmp/photospider-scheduler-doxygen
 ```
 
+CLI/Host 审计将
+`apps/graph_cli/src/cli_config.cpp::apply_cli_scheduler_defaults` 视为 scheduler
+默认值的 canonical 定义，并在该 translation unit 中验证其完整 Doxygen。工具会另外审计
+`run_graph_cli` 及其资源耗尽策略。对于 `ConfigEditor::SyncUiStateToModel`，两个解析链都必须
+重新抛出 `std::bad_alloc`。Scheduler worker 校验会单独处理 `std::invalid_argument`，而
+history-size 的 `std::stoi` 只通过一个 broad `catch (...)` 忽略其他错误；因此 catalog 对该函数
+只期望一个 broad catch，且其前面必须有 `std::bad_alloc` handler 保护。
+
 这些文件可以留在 primary repository，因为本文定义了它们的长期手工职责；它们必须始终不进入
 CTest 与 GitHub CI。其 `--out` 目录是仓库外、可丢弃的临时工作目录，不得成为长期 result tree。
 Issue 专属 replay、provenance、helper 和 output artifact 既不得进入 primary

--- a/tests/verification/codebase_structure/cli_host_doxygen_ast.py
+++ b/tests/verification/codebase_structure/cli_host_doxygen_ast.py
@@ -533,7 +533,7 @@ GUARD_DEFINITIONS = (
     ("apps/graph_cli/src/command/command_print.cpp", "handle_print", 1),
     ("apps/graph_cli/src/command/command_switch.cpp", "handle_switch", 2),
     ("apps/graph_cli/src/command/help_utils.cpp", "print_help_from_file", 1),
-    ("apps/graph_cli/src/config_editor.cpp", "SyncUiStateToModel", 2),
+    ("apps/graph_cli/src/config_editor.cpp", "SyncUiStateToModel", 1),
     ("apps/graph_cli/src/process_command.cpp", "process_command", 1),
     ("apps/graph_cli/src/cli_config.cpp", "write_config_to_file", 1),
     ("apps/graph_cli/src/cli_config.cpp", "load_or_create_config", 1),
@@ -1706,7 +1706,9 @@ def inspect_semantics(repo: Path) -> dict[str, Any]:
       Host/bad-alloc/lifetime checks.
     @throws OSError If a maintained CLI file cannot be read.
     @note These focused human-review proxies complement, but do not replace, the
-      compiler AST's structural Doxygen validation. ``InteractionService`` is
+      compiler AST's structural Doxygen validation. Scheduler-default Doxygen
+      follows its canonical ``cli_config.cpp`` definition, while
+      ``run_graph_cli`` remains a separate boundary. ``InteractionService`` is
       a permanently unsupported frontend dependency, so this terminology guard
       remains useful after the application-layout migration is complete.
     """
@@ -1810,7 +1812,7 @@ def inspect_semantics(repo: Path) -> dict[str, Any]:
             for source, function_name in (
                 (cli_config_source, "write_config_to_file"),
                 (cli_config_source, "load_or_create_config"),
-                (cli_run_source, "apply_scheduler_config"),
+                (cli_config_source, "apply_cli_scheduler_defaults"),
                 (cli_run_source, "load_configured_scheduler_plugins"),
                 (cli_run_source, "run_graph_cli"),
                 (graph_cli_source, "main"),
@@ -1896,8 +1898,8 @@ def make_expected() -> dict[str, Any]:
         "guard_definitions": {
             "expected_count": 16,
             "observed_count": 16,
-            "expected_broad_catch_count": 23,
-            "actual_broad_catch_count": 23,
+            "expected_broad_catch_count": 22,
+            "actual_broad_catch_count": 22,
             "missing": [],
             "invalid": [],
             "target_source_counts": EXPECTED_CLI_TARGET_SOURCE_COUNTS,


### PR DESCRIPTION
## Summary

- Correct the `SyncUiStateToModel` broad-catch inventory from two to one while preserving both `std::bad_alloc` guards.
- Move the scheduler-default Doxygen semantic proxy from the removed `apply_scheduler_config` symbol to canonical `cli_config.cpp::apply_cli_scheduler_defaults`.
- Document the canonical symbol and exception boundary in the authoritative English validation guide and its faithful Chinese mirror.

## Root cause and impact

Two audit assumptions were stale after the CLI scheduler-default and editor exception-boundary corrections reached `main`. The long-lived manual developer tool therefore failed even though the current implementation was safe. This PR changes only the manual audit and documentation: there is no runtime, API, build, CTest, or GitHub CI behavior change.

## RED → GREEN evidence

Using `build/issue50-final/compile_commands.json`:

1. Initial normal audit: exit 1; 56/56 declarations, 56/56 definitions, 72/72 extended entities, and 60/60 target sources passed, with only broad catches 22/23 and the stale scheduler semantic proxy failing.
2. After the first vertical slice: exit 1; broad catches became 22/22 with no invalid or uncatalogued entries, leaving only the stale scheduler symbol failure.
3. After migrating the canonical symbol: exit 0; all six comparison groups passed with 56/56 declarations, 56/56 definitions, 72/72 extended entities, 22/22 broad catches, and 60/60 target sources.
4. After documentation freeze: the same normal audit remained exit 0.

The four built-in negative mutations were each rejected (`deleted_comment`, `wrong_copydoc`, `deleted_param`, and `deleted_inventory` all had case return code 1), while the aggregate self-test exited 0 with `passes=true`.

## Validation

- `python3 tests/verification/codebase_structure/cli_host_doxygen_ast.py --repo . --compile-commands build/issue50-final/compile_commands.json --out /tmp/issue42-cli-host-doxygen-final`
- `python3 tests/verification/codebase_structure/cli_host_doxygen_ast.py --repo . --compile-commands build/issue50-final/compile_commands.json --out /tmp/issue42-cli-host-doxygen-negative --negative-self-test`
- `python3 -m py_compile tests/verification/codebase_structure/cli_host_doxygen_ast.py`
- `python3 -m black --check tests/verification/codebase_structure/cli_host_doxygen_ast.py`
- `git diff --check`
- `CI_BASE_REF=origin/main bash ci/scripts/healthcheck.sh`

All passed. The exact healthcheck ran once after the primary commit and before push; it passed `git_diff_check` and correctly skipped C++ format/lint because this PR changes no C++ files.

The manual Doxygen tool is intentionally absent from CTest and GitHub CI under repository Test Ownership policy, so the local normal and negative tool runs above are the direct gate for this fix. Remote Healthcheck and Integration remain the repository-wide integration gate.

Related to #42. This PR intentionally does not close the issue; #42 remains open for independent final audit.