### PR TITLE
[fix] relocate graph test fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ feedback/
 !tests/**/*.cpp
 !tests/**/*.hpp
 !tests/**/*.py
+!tests/fixtures/graphs/*.yaml
 tests/results/
 
 # ============================

--- a/ci/scripts/graph_cli_script_test.sh
+++ b/ci/scripts/graph_cli_script_test.sh
@@ -59,7 +59,7 @@ printf 'Graph document missing-source contract: %s\n' \
 ensure_ci_configured cmake_configure
 ensure_ci_targets build_graph_cli graph_cli cpu_work_stealing_example_plugin serial_debug_example_plugin
 
-fixture_path="$REPO_ROOT/util/testcases/propagation_linear_test.yaml"
+fixture_path="$REPO_ROOT/tests/fixtures/graphs/propagation_linear_test.yaml"
 runtime_root=$(mktemp -d "$CI_ARTIFACT_DIR/graph_cli_runtime.XXXXXX")
 
 # Preserve failed runtimes inside the uploaded artifact tree while removing

--- a/ci/scripts/propagation_script_test.sh
+++ b/ci/scripts/propagation_script_test.sh
@@ -13,20 +13,26 @@ ensure_ci_targets build_propagation_tool test_propagation
 
 linear_log="$CI_ARTIFACT_DIR/propagation_linear_tiles.log"
 printf 'tiles all\nexit\n' |
-  "$BUILD_DIR/tests/test_propagation" util/testcases/propagation_linear_test.yaml \
+  "$BUILD_DIR/tests/test_propagation" \
+    tests/fixtures/graphs/propagation_linear_test.yaml \
     > "$linear_log" 2>&1
 
-require_grep "Graph loaded from 'util/testcases/propagation_linear_test.yaml'" "$linear_log"
+require_grep \
+  "Graph loaded from 'tests/fixtures/graphs/propagation_linear_test.yaml'" \
+  "$linear_log"
 require_grep "1 UNDEFINED 16 16 1024 1024" "$linear_log"
 require_grep "2 MACRO 4 4 1024 1024" "$linear_log"
 require_grep "200 MACRO 2 2 512 512" "$linear_log"
 
 complex_log="$CI_ARTIFACT_DIR/propagation_complex_tiles.log"
 printf 'tiles all\nexit\n' |
-  "$BUILD_DIR/tests/test_propagation" util/testcases/propagation_complex_test.yaml \
+  "$BUILD_DIR/tests/test_propagation" \
+    tests/fixtures/graphs/propagation_complex_test.yaml \
     > "$complex_log" 2>&1
 
-require_grep "Graph loaded from 'util/testcases/propagation_complex_test.yaml'" "$complex_log"
+require_grep \
+  "Graph loaded from 'tests/fixtures/graphs/propagation_complex_test.yaml'" \
+  "$complex_log"
 require_grep "10 UNDEFINED 8 8 512 512" "$complex_log"
 require_grep "20 UNDEFINED 8 8 512 512" "$complex_log"
 require_grep "200 MACRO 2 2 512 512" "$complex_log"

--- a/tests/fixtures/graphs/dirty_region_test.yaml
+++ b/tests/fixtures/graphs/dirty_region_test.yaml
@@ -1,0 +1,27 @@
+- id: 1
+  name: Canvas_Source
+  type: image_generator
+  subtype: constant
+  parameters:
+    width: 1024
+    height: 1024
+    value: 128
+    channels: 1
+
+- id: 2
+  name: Heavy_Blur
+  type: image_process
+  subtype: micro_blur_for_test
+  image_inputs:
+    - from_node_id: 1
+  parameters:
+    ksize: 25 # 一个较大的核，确保计算有负载
+
+- id: 3
+  name: Final_Output
+  type: image_process
+  subtype: curve_transform # 另一个简单的操作
+  image_inputs:
+    - from_node_id: 2
+  parameters:
+    k: 1.5

--- a/tests/fixtures/graphs/propagation_complex_test.yaml
+++ b/tests/fixtures/graphs/propagation_complex_test.yaml
@@ -1,0 +1,67 @@
+# 1. 起点：一个1024x1024的大尺寸数据源
+- id: 1
+  name: SourceImage
+  type: image_generator
+  subtype: constant
+  parameters:
+    width: 1024
+    height: 1024
+    value: 128
+
+# 2. 模糊：对源图像进行一次高斯模糊，这将引入邻域计算
+#    ksize=21 意味着计算半径为10像素，会显著扩大脏区
+- id: 2
+  name: GaussianBlur_Base
+  type: image_process
+  subtype: gaussian_blur
+  image_inputs:
+    - from_node_id: 1
+  parameters:
+    ksize: 21
+
+# 3. 扇出 (Fan-out)：从模糊后的图像创建两个并行分支
+
+#    分支A：裁剪出一个512x512的区域。这将测试“窗口化”传播。
+- id: 10
+  name: Crop_Quadrant
+  type: image_process
+  subtype: crop
+  image_inputs:
+    - from_node_id: 2
+  parameters:
+    x: 200
+    y: 300
+    width: 512
+    height: 512
+
+#    分支B：将整个图像缩放到512x512。这将测试“缩放”传播。
+- id: 20
+  name: Resize_Half
+  type: image_process
+  subtype: resize
+  image_inputs:
+    - from_node_id: 2
+  parameters:
+    width: 512
+    height: 512
+
+# 4. 扇入 (Fan-in)：将裁剪和缩放后的两个分支结果合并
+#    这个节点的脏区将是两个上游分支脏区的并集。
+- id: 100
+  name: Merge_Crop_Resize
+  type: image_mixing
+  subtype: add_weighted
+  image_inputs:
+    - from_node_id: 10 # 来自裁剪分支
+    - from_node_id: 20 # 来自缩放分支
+  parameters:
+    alpha: 0.5
+    beta: 0.5
+
+# 5. 最终输出节点
+- id: 200
+  name: FinalOutput
+  type: image_process
+  subtype: curve_transform
+  image_inputs:
+    - from_node_id: 100

--- a/tests/fixtures/graphs/propagation_linear_test.yaml
+++ b/tests/fixtures/graphs/propagation_linear_test.yaml
@@ -1,0 +1,38 @@
+# 1. 起点
+- id: 1
+  name: SourceImage
+  type: image_generator
+  subtype: constant
+  parameters:
+    width: 1024
+    height: 1024
+    value: 128
+
+# 2. 模糊
+- id: 2
+  name: GaussianBlur_Base
+  type: image_process
+  subtype: gaussian_blur
+  image_inputs:
+    - from_node_id: 1
+  parameters:
+    ksize: 21
+
+# 3. 缩放分支 (现在是主干路)
+- id: 20
+  name: Resize_Half
+  type: image_process
+  subtype: resize
+  image_inputs:
+    - from_node_id: 2
+  parameters:
+    width: 512
+    height: 512
+
+# 4. 最终输出 (直接依赖于缩放分支)
+- id: 200
+  name: FinalOutput
+  type: image_process
+  subtype: curve_transform
+  image_inputs:
+    - from_node_id: 20

--- a/tests/fixtures/graphs/scheduler_test_parallel.yaml
+++ b/tests/fixtures/graphs/scheduler_test_parallel.yaml
@@ -1,0 +1,121 @@
+# FILE: scheduler_test_parallel.yaml
+
+# 1. 起点：一个所有分支都依赖的单一数据源
+- id: 1
+  name: The_Source
+  type: image_generator
+  subtype: constant
+  parameters:
+    width: 512
+    height: 512
+    value: 128
+    channels: 3
+
+# 2. 扇出 (Fan-out)：创建4个并行的模糊处理分支，它们都依赖于节点1
+#    一旦节点1完成，这4个节点应被不同线程并行执行。
+- id: 10
+  name: Branch_A_Blur
+  type: image_process
+  subtype: gaussian_blur
+  image_inputs:
+    - from_node_id: 1
+  parameters:
+    ksize: 5
+
+- id: 20
+  name: Branch_B_Blur
+  type: image_process
+  subtype: gaussian_blur
+  image_inputs:
+    - from_node_id: 1
+  parameters:
+    ksize: 15
+
+- id: 30
+  name: Branch_C_Blur
+  type: image_process
+  subtype: gaussian_blur
+  image_inputs:
+    - from_node_id: 1
+  parameters:
+    ksize: 25
+
+- id: 40
+  name: Branch_D_Blur
+  type: image_process
+  subtype: gaussian_blur
+  image_inputs:
+    - from_node_id: 1
+  parameters:
+    ksize: 35
+
+# 3. 短链：在每个并行分支后再加一个节点，增加一点深度
+- id: 11
+  name: Branch_A_Curve
+  type: image_process
+  subtype: curve_transform
+  image_inputs:
+    - from_node_id: 10
+  parameters:
+    k: 0.5
+
+- id: 21
+  name: Branch_B_Curve
+  type: image_process
+  subtype: curve_transform
+  image_inputs:
+    - from_node_id: 20
+  parameters:
+    k: 1.5
+
+- id: 31
+  name: Branch_C_Curve
+  type: image_process
+  subtype: curve_transform
+  image_inputs:
+    - from_node_id: 30
+  parameters:
+    k: 2.5
+
+- id: 41
+  name: Branch_D_Curve
+  type: image_process
+  subtype: curve_transform
+  image_inputs:
+    - from_node_id: 40
+  parameters:
+    k: 3.5
+
+# 4. 扇入 (Fan-in)：将并行的结果两两合并，测试依赖同步
+#    节点100 必须等待 11 和 21 都完成
+- id: 100
+  name: Merge_AB
+  type: image_mixing
+  subtype: add_weighted
+  image_inputs:
+    - from_node_id: 11
+    - from_node_id: 21
+  parameters:
+    alpha: 0.5
+    beta: 0.5
+
+#    节点101 必须等待 31 和 41 都完成
+- id: 101
+  name: Merge_CD
+  type: image_mixing
+  subtype: add_weighted
+  image_inputs:
+    - from_node_id: 31
+    - from_node_id: 41
+  parameters:
+    alpha: 0.7
+    beta: 0.3
+
+# 5. 最终合并：计算最终节点，作为整个图的终点
+- id: 200
+  name: Final_Merge
+  type: image_mixing
+  subtype: multiply
+  image_inputs:
+    - from_node_id: 100
+    - from_node_id: 101

--- a/tests/integration/test_compute_service_split.cpp
+++ b/tests/integration/test_compute_service_split.cpp
@@ -3701,7 +3701,7 @@ TEST(DirtySourceLifecycleFacade, UsesHostPublicBoundary) {
   GraphLoadRequest load_request;
   load_request.session = GraphSessionId{"dirty_facade"};
   load_request.root_dir = "sessions";
-  load_request.yaml_path = "util/testcases/dirty_region_test.yaml";
+  load_request.yaml_path = "tests/fixtures/graphs/dirty_region_test.yaml";
   const auto loaded = host->load_graph(load_request);
   ASSERT_TRUE(loaded.status.ok) << loaded.status.message;
 
@@ -3741,8 +3741,9 @@ TEST(DirtyControlLaneFacade, ExposesWakeupAndCutoffThroughInteractionService) {
   InteractionService svc(kernel);
   svc.cmd_seed_builtin_ops();
 
-  auto loaded = svc.cmd_load_graph("dirty_control_lane", "sessions",
-                                   "util/testcases/dirty_region_test.yaml");
+  auto loaded =
+      svc.cmd_load_graph("dirty_control_lane", "sessions",
+                         "tests/fixtures/graphs/dirty_region_test.yaml");
   ASSERT_TRUE(loaded.has_value());
 
   auto begin = svc.cmd_begin_dirty_source_control(

--- a/tests/integration/test_gpu_pipeline_scheduler.cpp
+++ b/tests/integration/test_gpu_pipeline_scheduler.cpp
@@ -855,7 +855,8 @@ TEST(GpuPipelineIntegrationTest, SchedulerWithRuntime) {
 
   svc.cmd_seed_builtin_ops();
   const std::string graph_name = "gpu_pipeline_test";
-  const std::string graph_path = "util/testcases/scheduler_test_parallel.yaml";
+  const std::string graph_path =
+      "tests/fixtures/graphs/scheduler_test_parallel.yaml";
   auto loaded = svc.cmd_load_graph(graph_name, "sessions", graph_path);
 
   // 如果测试图不存在，跳过测试
@@ -909,7 +910,8 @@ TEST(GpuPipelineIntegrationTest, DualSchedulerConcurrentExecution) {
 
   svc.cmd_seed_builtin_ops();
   const std::string graph_name = "dual_scheduler_test";
-  const std::string graph_path = "util/testcases/scheduler_test_parallel.yaml";
+  const std::string graph_path =
+      "tests/fixtures/graphs/scheduler_test_parallel.yaml";
   auto loaded = svc.cmd_load_graph(graph_name, "sessions", graph_path);
 
   if (!loaded.has_value()) {

--- a/tests/integration/test_milestone34.cpp
+++ b/tests/integration/test_milestone34.cpp
@@ -89,7 +89,8 @@ TEST(M34_KernelScheduler, LoadGraphInjectsSchedulers) {
 
   svc.cmd_seed_builtin_ops();
   const std::string graph_name = "m34_scheduler_test";
-  const std::string graph_path = "util/testcases/scheduler_test_parallel.yaml";
+  const std::string graph_path =
+      "tests/fixtures/graphs/scheduler_test_parallel.yaml";
 
   auto loaded = svc.cmd_load_graph(graph_name, "sessions", graph_path);
   ASSERT_TRUE(loaded.has_value());
@@ -124,7 +125,8 @@ TEST(M34_KernelScheduler, CustomSchedulerConfigOnLoad) {
   svc.cmd_seed_builtin_ops();
 
   const std::string graph_name = "m34_custom_scheduler_test";
-  const std::string graph_path = "util/testcases/scheduler_test_parallel.yaml";
+  const std::string graph_path =
+      "tests/fixtures/graphs/scheduler_test_parallel.yaml";
 
   auto loaded = svc.cmd_load_graph(graph_name, "sessions", graph_path);
   ASSERT_TRUE(loaded.has_value());
@@ -152,7 +154,8 @@ TEST(M34_KernelScheduler, ReplaceScheduler) {
 
   svc.cmd_seed_builtin_ops();
   const std::string graph_name = "m34_replace_scheduler_test";
-  const std::string graph_path = "util/testcases/scheduler_test_parallel.yaml";
+  const std::string graph_path =
+      "tests/fixtures/graphs/scheduler_test_parallel.yaml";
 
   auto loaded = svc.cmd_load_graph(graph_name, "sessions", graph_path);
   ASSERT_TRUE(loaded.has_value());
@@ -185,7 +188,8 @@ TEST(M34_KernelScheduler, ReplaceSchedulerInvalidType) {
 
   svc.cmd_seed_builtin_ops();
   const std::string graph_name = "m34_invalid_replace_test";
-  const std::string graph_path = "util/testcases/scheduler_test_parallel.yaml";
+  const std::string graph_path =
+      "tests/fixtures/graphs/scheduler_test_parallel.yaml";
 
   auto loaded = svc.cmd_load_graph(graph_name, "sessions", graph_path);
   ASSERT_TRUE(loaded.has_value());
@@ -251,7 +255,8 @@ TEST(M34_Integration, ComputeWithInjectedScheduler) {
 
   svc.cmd_seed_builtin_ops();
   const std::string graph_name = "m34_compute_test";
-  const std::string graph_path = "util/testcases/scheduler_test_parallel.yaml";
+  const std::string graph_path =
+      "tests/fixtures/graphs/scheduler_test_parallel.yaml";
 
   auto loaded = svc.cmd_load_graph(graph_name, "sessions", graph_path);
   ASSERT_TRUE(loaded.has_value());
@@ -293,7 +298,8 @@ TEST(M34_Integration, ComputeWithSerialScheduler) {
   svc.cmd_seed_builtin_ops();
 
   const std::string graph_name = "m34_serial_compute_test";
-  const std::string graph_path = "util/testcases/scheduler_test_parallel.yaml";
+  const std::string graph_path =
+      "tests/fixtures/graphs/scheduler_test_parallel.yaml";
 
   auto loaded = svc.cmd_load_graph(graph_name, "sessions", graph_path);
   ASSERT_TRUE(loaded.has_value());

--- a/tests/integration/test_scheduler.cpp
+++ b/tests/integration/test_scheduler.cpp
@@ -212,7 +212,8 @@ TEST(SchedulerTestM33, ParallelComputeWithNewScheduler) {
 
   svc.cmd_seed_builtin_ops();
   const std::string graph_name = "scheduler_m33_test";
-  const std::string graph_path = "util/testcases/scheduler_test_parallel.yaml";
+  const std::string graph_path =
+      "tests/fixtures/graphs/scheduler_test_parallel.yaml";
   auto loaded = svc.cmd_load_graph(graph_name, "sessions", graph_path);
   ASSERT_TRUE(loaded.has_value());
 
@@ -257,7 +258,8 @@ TEST(SchedulerTest, ParallelLogToJson) {
 
   svc.cmd_seed_builtin_ops();
   const std::string graph_name = "scheduler_ci_graph";
-  const std::string graph_path = "util/testcases/scheduler_test_parallel.yaml";
+  const std::string graph_path =
+      "tests/fixtures/graphs/scheduler_test_parallel.yaml";
   auto loaded = svc.cmd_load_graph(graph_name, "sessions", graph_path);
   ASSERT_TRUE(loaded.has_value());
 
@@ -300,7 +302,7 @@ TEST(Scheduler, DirtyRegionTiledComputation) {
   svc.cmd_seed_builtin_ops();
   register_micro_blur_for_dirty_scheduler_tests();
   const std::string graph_name = "dirty_region_test";
-  const std::string yaml_path = "util/testcases/dirty_region_test.yaml";
+  const std::string yaml_path = "tests/fixtures/graphs/dirty_region_test.yaml";
   const int final_node_id = 3;
 
   // 加载图
@@ -494,7 +496,7 @@ TEST(Scheduler,
 
   const std::string stale_graph_name = "dirty_region_stale_generation_test";
   ASSERT_TRUE(svc.cmd_load_graph(stale_graph_name, "sessions",
-                                 "util/testcases/dirty_region_test.yaml")
+                                 "tests/fixtures/graphs/dirty_region_test.yaml")
                   .has_value());
   ps::GraphRuntime& stale_runtime =
       ps::testing::KernelTestAccess::runtime(kernel, stale_graph_name);
@@ -547,7 +549,7 @@ TEST(Scheduler,
 
   const std::string exception_graph_name = "dirty_region_exception_test";
   ASSERT_TRUE(svc.cmd_load_graph(exception_graph_name, "sessions",
-                                 "util/testcases/dirty_region_test.yaml")
+                                 "tests/fixtures/graphs/dirty_region_test.yaml")
                   .has_value());
   ps::GraphRuntime& exception_runtime =
       ps::testing::KernelTestAccess::runtime(kernel, exception_graph_name);
@@ -623,7 +625,7 @@ TEST(Scheduler, ConcurrentDirtySiblingsPreserveYamlParameterState) {
 
   const std::string graph_name = "dirty_region_yaml_sibling_test";
   ASSERT_TRUE(svc.cmd_load_graph(graph_name, "sessions",
-                                 "util/testcases/dirty_region_test.yaml")
+                                 "tests/fixtures/graphs/dirty_region_test.yaml")
                   .has_value());
   ps::GraphRuntime& runtime =
       ps::testing::KernelTestAccess::runtime(kernel, graph_name);


### PR DESCRIPTION
## 变更内容

- 将 `propagation_linear_test.yaml`、`propagation_complex_test.yaml`、`scheduler_test_parallel.yaml` 和 `dirty_region_test.yaml` 恢复到 `tests/fixtures/graphs/`。
- 更新 CI 脚本与集成测试，移除对已删除 `util/testcases/` 的依赖。
- 更新 `.gitignore`，允许主仓跟踪 graph YAML fixtures。

## 原因与影响

主仓移除 `util/` 后，CI 与集成测试仍引用其中的 graph fixtures，导致干净 checkout 无法独立运行相关测试。本变更把长期测试数据归入 `tests/fixtures/graphs/`；不改变公开 API 或运行时行为。

## 验证

### 本地

- 聚焦 CTest：15/15 通过
- `ci/scripts/graph_cli_script_test.sh`：通过
- `ci/scripts/propagation_script_test.sh`：通过
- ClangFormat 21.1.3 dry-run：通过
- `python3 -m cpplint`：通过
- `bash -n`：通过
- YAML 解析、历史语义一致性与 `git diff --check`：通过
- 独立一级审核：零 actionable finding

### GitHub Actions

- CI Integration：全部通过
- 默认与 IPC-disabled 构建完整性：通过
- 完整 CTest：通过
- propagation/scripted CLI、scheduler、plugin、install/static consumer smoke：通过

## 风险

风险较低：fixture 语义保持不变，修改集中在测试数据位置及其引用路径。