### PR TITLE
fix(ci): derive exact smoke inventories from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+include("${PROJECT_SOURCE_DIR}/cmake/PhotospiderCiInventory.cmake")
 
 # --- Compiler Settings ---
 set(CMAKE_CXX_STANDARD 17)
@@ -227,15 +228,9 @@ endforeach()
 set(PHOTOSPIDER_CI_INVENTORY_DIR
     "${CMAKE_BINARY_DIR}/generated/ci_inventory")
 file(MAKE_DIRECTORY "${PHOTOSPIDER_CI_INVENTORY_DIR}")
-set(PHOTOSPIDER_PUBLIC_HEADER_INVENTORY_CONTENT "")
-foreach(PUBLIC_HEADER_RELATIVE_PATH
-        IN LISTS PHOTOSPIDER_INSTALLABLE_PUBLIC_HEADER_RELATIVE_PATHS)
-    string(APPEND PHOTOSPIDER_PUBLIC_HEADER_INVENTORY_CONTENT
-        "include/photospider/${PUBLIC_HEADER_RELATIVE_PATH}\n")
-endforeach()
-file(WRITE
+photospider_write_public_header_inventory(
     "${PHOTOSPIDER_CI_INVENTORY_DIR}/installable_public_headers.txt"
-    "${PHOTOSPIDER_PUBLIC_HEADER_INVENTORY_CONTENT}")
+    PHOTOSPIDER_INSTALLABLE_PUBLIC_HEADER_RELATIVE_PATHS)
 # Linked consumers receive only the public include root. Kernel/Interaction
 # facades live under src/lib/ as source-tree internals: repository targets that
 # include them must use the private roots below, and the installable
@@ -1804,6 +1799,7 @@ if(PHOTOSPIDER_BUILD_FULL_TEST_SUITE)
         COMMAND ${Python3_EXECUTABLE} -B
             "${PROJECT_SOURCE_DIR}/tests/integration/install_consumer_architecture_propagation_test.py"
             --build-dir "${CMAKE_BINARY_DIR}"
+            --cmake-executable "${CMAKE_COMMAND}"
             --ctest-executable "${CMAKE_CTEST_COMMAND}"
             --config "$<CONFIG>"
             --python-executable "${Python3_EXECUTABLE}"
@@ -1867,6 +1863,8 @@ if(PHOTOSPIDER_BUILD_FULL_TEST_SUITE)
                 "${PROJECT_SOURCE_DIR}/tests/integration")
         set_tests_properties(
             OpenCvOperationProviderBuildSmokeSafety PROPERTIES
+            ENVIRONMENT
+                "PHOTOSPIDER_CMAKE_EXECUTABLE=${CMAKE_COMMAND}"
             TIMEOUT 30)
         add_test(NAME OpenCvOperationProviderDisabledBuild
             COMMAND ${Python3_EXECUTABLE}
@@ -2046,17 +2044,9 @@ if(BUILD_TESTING)
         message(FATAL_ERROR
             "CTest include inventory does not match registered GoogleTest targets")
     endif()
-    set(PHOTOSPIDER_GTEST_TARGET_INVENTORY_CONTENT
-        "# target\tconfigured executable\n")
-    foreach(PHOTOSPIDER_REGISTERED_GTEST_TARGET
-            IN LISTS PHOTOSPIDER_REGISTERED_GTEST_TARGETS)
-        string(APPEND PHOTOSPIDER_GTEST_TARGET_INVENTORY_CONTENT
-            "${PHOTOSPIDER_REGISTERED_GTEST_TARGET}\t$<TARGET_FILE:${PHOTOSPIDER_REGISTERED_GTEST_TARGET}>\n")
-    endforeach()
-    file(GENERATE
-        OUTPUT
-            "${PHOTOSPIDER_CI_INVENTORY_DIR}/registered_gtest_targets-$<CONFIG>.tsv"
-        CONTENT "${PHOTOSPIDER_GTEST_TARGET_INVENTORY_CONTENT}")
+    photospider_generate_registered_gtest_target_inventory(
+        "${PHOTOSPIDER_CI_INVENTORY_DIR}/registered_gtest_targets-$<CONFIG>.tsv"
+        PHOTOSPIDER_REGISTERED_GTEST_TARGETS)
 endif()
 
 # The test-only product must have a closed direct-consumer set, and no target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,22 @@ foreach(EXISTING_PUBLIC_HEADER ${PHOTOSPIDER_EXISTING_BUILD_PUBLIC_HEADERS})
         file(REMOVE "${EXISTING_PUBLIC_HEADER}")
     endif()
 endforeach()
+# Package-consumer validation reads the configured allowlist rather than
+# duplicating its size or scanning the source tree. Keep the build-tree
+# manifest path stable and serialize install-relative paths one per line so
+# missing and unexpected installed files can be diagnosed as an exact set.
+set(PHOTOSPIDER_CI_INVENTORY_DIR
+    "${CMAKE_BINARY_DIR}/generated/ci_inventory")
+file(MAKE_DIRECTORY "${PHOTOSPIDER_CI_INVENTORY_DIR}")
+set(PHOTOSPIDER_PUBLIC_HEADER_INVENTORY_CONTENT "")
+foreach(PUBLIC_HEADER_RELATIVE_PATH
+        IN LISTS PHOTOSPIDER_INSTALLABLE_PUBLIC_HEADER_RELATIVE_PATHS)
+    string(APPEND PHOTOSPIDER_PUBLIC_HEADER_INVENTORY_CONTENT
+        "include/photospider/${PUBLIC_HEADER_RELATIVE_PATH}\n")
+endforeach()
+file(WRITE
+    "${PHOTOSPIDER_CI_INVENTORY_DIR}/installable_public_headers.txt"
+    "${PHOTOSPIDER_PUBLIC_HEADER_INVENTORY_CONTENT}")
 # Linked consumers receive only the public include root. Kernel/Interaction
 # facades live under src/lib/ as source-tree internals: repository targets that
 # include them must use the private roots below, and the installable
@@ -1987,6 +2003,60 @@ if(PHOTOSPIDER_BUILD_FULL_TEST_SUITE)
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         PROPERTIES TIMEOUT 60)
     gtest_discover_tests(test_node_editor_layout WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+endif()
+
+# GoogleTest.cmake records each gtest_discover_tests registration in the
+# directory TEST_INCLUDE_FILES property and sets CTEST_DISCOVERED_TEST_COUNTER
+# on its executable target. Cross-check those two CMake-owned views, then expose
+# the exact target/configuration executable mapping to nested-profile drivers.
+# A driver can consequently derive registered-but-unbuilt `_NOT_BUILT`
+# placeholders from real target existence without maintaining a target count or
+# guessing future target names.
+if(BUILD_TESTING)
+    get_property(PHOTOSPIDER_CTEST_INCLUDE_FILES DIRECTORY
+        PROPERTY TEST_INCLUDE_FILES)
+    get_property(PHOTOSPIDER_INVENTORY_ROOT_TARGETS DIRECTORY
+        PROPERTY BUILDSYSTEM_TARGETS)
+    set(PHOTOSPIDER_REGISTERED_GTEST_TARGETS "")
+    set(PHOTOSPIDER_EXPECTED_GTEST_INCLUDE_FILES "")
+    foreach(PHOTOSPIDER_INVENTORY_ROOT_TARGET
+            IN LISTS PHOTOSPIDER_INVENTORY_ROOT_TARGETS)
+        get_property(PHOTOSPIDER_GTEST_COUNTER_IS_SET
+            TARGET ${PHOTOSPIDER_INVENTORY_ROOT_TARGET}
+            PROPERTY CTEST_DISCOVERED_TEST_COUNTER SET)
+        if(PHOTOSPIDER_GTEST_COUNTER_IS_SET)
+            get_property(PHOTOSPIDER_GTEST_COUNTER
+                TARGET ${PHOTOSPIDER_INVENTORY_ROOT_TARGET}
+                PROPERTY CTEST_DISCOVERED_TEST_COUNTER)
+            if(NOT PHOTOSPIDER_GTEST_COUNTER EQUAL 1)
+                message(FATAL_ERROR
+                    "GoogleTest target ${PHOTOSPIDER_INVENTORY_ROOT_TARGET} is registered ${PHOTOSPIDER_GTEST_COUNTER} times; inventory requires one registration")
+            endif()
+            list(APPEND PHOTOSPIDER_REGISTERED_GTEST_TARGETS
+                ${PHOTOSPIDER_INVENTORY_ROOT_TARGET})
+            list(APPEND PHOTOSPIDER_EXPECTED_GTEST_INCLUDE_FILES
+                "${CMAKE_CURRENT_BINARY_DIR}/${PHOTOSPIDER_INVENTORY_ROOT_TARGET}[${PHOTOSPIDER_GTEST_COUNTER}]_include.cmake")
+        endif()
+    endforeach()
+    list(SORT PHOTOSPIDER_CTEST_INCLUDE_FILES)
+    list(SORT PHOTOSPIDER_EXPECTED_GTEST_INCLUDE_FILES)
+    list(SORT PHOTOSPIDER_REGISTERED_GTEST_TARGETS)
+    if(NOT PHOTOSPIDER_CTEST_INCLUDE_FILES STREQUAL
+            PHOTOSPIDER_EXPECTED_GTEST_INCLUDE_FILES)
+        message(FATAL_ERROR
+            "CTest include inventory does not match registered GoogleTest targets")
+    endif()
+    set(PHOTOSPIDER_GTEST_TARGET_INVENTORY_CONTENT
+        "# target\tconfigured executable\n")
+    foreach(PHOTOSPIDER_REGISTERED_GTEST_TARGET
+            IN LISTS PHOTOSPIDER_REGISTERED_GTEST_TARGETS)
+        string(APPEND PHOTOSPIDER_GTEST_TARGET_INVENTORY_CONTENT
+            "${PHOTOSPIDER_REGISTERED_GTEST_TARGET}\t$<TARGET_FILE:${PHOTOSPIDER_REGISTERED_GTEST_TARGET}>\n")
+    endforeach()
+    file(GENERATE
+        OUTPUT
+            "${PHOTOSPIDER_CI_INVENTORY_DIR}/registered_gtest_targets-$<CONFIG>.tsv"
+        CONTENT "${PHOTOSPIDER_GTEST_TARGET_INVENTORY_CONTENT}")
 endif()
 
 # The test-only product must have a closed direct-consumer set, and no target

--- a/cmake/PhotospiderCiInventory.cmake
+++ b/cmake/PhotospiderCiInventory.cmake
@@ -1,0 +1,131 @@
+# @brief Reject bytes that cannot be represented safely in a line manifest.
+#
+# @param FIELD_CONTEXT Controlled diagnostic context that identifies the field
+#   position without reproducing its untrusted contents.
+# @param FIELD_VALUE Exact CMake string that would otherwise be serialized.
+# @param ALLOW_BACKSLASH Whether a backslash is data rather than a path-format
+#   violation at this manifest boundary.
+# @return None; validation success leaves the caller's state unchanged.
+# @throws FATAL_ERROR If FIELD_VALUE contains a disallowed backslash, an ASCII
+#   control character in the range 1 through 31, or ASCII DEL (127).
+# @note CMake strings cannot represent NUL. Downstream readers still reject NUL
+#   so forged or externally modified manifests fail closed.
+function(_photospider_require_ci_inventory_field
+        FIELD_CONTEXT FIELD_VALUE ALLOW_BACKSLASH)
+    if(NOT ALLOW_BACKSLASH)
+        string(FIND "${FIELD_VALUE}" "\\" PHOTOSPIDER_BACKSLASH_OFFSET)
+        if(NOT PHOTOSPIDER_BACKSLASH_OFFSET EQUAL -1)
+            message(FATAL_ERROR
+                "${FIELD_CONTEXT} contains a forbidden backslash")
+        endif()
+    endif()
+
+    foreach(PHOTOSPIDER_CONTROL_CODE RANGE 1 31)
+        string(ASCII "${PHOTOSPIDER_CONTROL_CODE}"
+            PHOTOSPIDER_CONTROL_CHARACTER)
+        string(FIND "${FIELD_VALUE}" "${PHOTOSPIDER_CONTROL_CHARACTER}"
+            PHOTOSPIDER_CONTROL_OFFSET)
+        if(NOT PHOTOSPIDER_CONTROL_OFFSET EQUAL -1)
+            message(FATAL_ERROR
+                "${FIELD_CONTEXT} contains forbidden ASCII control "
+                "code ${PHOTOSPIDER_CONTROL_CODE}")
+        endif()
+    endforeach()
+
+    string(ASCII 127 PHOTOSPIDER_DELETE_CHARACTER)
+    string(FIND "${FIELD_VALUE}" "${PHOTOSPIDER_DELETE_CHARACTER}"
+        PHOTOSPIDER_DELETE_OFFSET)
+    if(NOT PHOTOSPIDER_DELETE_OFFSET EQUAL -1)
+        message(FATAL_ERROR
+            "${FIELD_CONTEXT} contains forbidden ASCII control code 127")
+    endif()
+endfunction()
+
+# @brief Serialize the configured installable public-header allowlist.
+#
+# @param OUTPUT_PATH Build-tree manifest path written during configuration.
+# @param HEADER_LIST_VARIABLE Name of the caller-owned CMake list containing
+#   paths relative to include/photospider.
+# @return None; writes one install-relative POSIX header path per line.
+# @throws FATAL_ERROR If an entry contains a backslash or a CMake-representable
+#   ASCII control character, or if the output cannot be written.
+# @note Ordinary spaces remain valid POSIX path data. Validation happens before
+#   any entry is appended, so a rejected field cannot inject another record.
+function(photospider_write_public_header_inventory
+        OUTPUT_PATH HEADER_LIST_VARIABLE)
+    set(PHOTOSPIDER_PUBLIC_HEADER_INVENTORY_CONTENT "")
+    set(PHOTOSPIDER_PUBLIC_HEADER_INDEX 0)
+    foreach(PHOTOSPIDER_PUBLIC_HEADER_RELATIVE_PATH
+            IN LISTS ${HEADER_LIST_VARIABLE})
+        math(EXPR PHOTOSPIDER_PUBLIC_HEADER_INDEX
+            "${PHOTOSPIDER_PUBLIC_HEADER_INDEX} + 1")
+        _photospider_require_ci_inventory_field(
+            "Public-header allowlist entry ${PHOTOSPIDER_PUBLIC_HEADER_INDEX}"
+            "${PHOTOSPIDER_PUBLIC_HEADER_RELATIVE_PATH}"
+            FALSE)
+        string(APPEND PHOTOSPIDER_PUBLIC_HEADER_INVENTORY_CONTENT
+            "include/photospider/${PHOTOSPIDER_PUBLIC_HEADER_RELATIVE_PATH}\n")
+    endforeach()
+
+    get_filename_component(PHOTOSPIDER_PUBLIC_HEADER_INVENTORY_DIRECTORY
+        "${OUTPUT_PATH}" DIRECTORY)
+    file(MAKE_DIRECTORY
+        "${PHOTOSPIDER_PUBLIC_HEADER_INVENTORY_DIRECTORY}")
+    file(WRITE "${OUTPUT_PATH}"
+        "${PHOTOSPIDER_PUBLIC_HEADER_INVENTORY_CONTENT}")
+endfunction()
+
+# @brief Generate the configuration-specific registered-GTest TSV manifest.
+#
+# @param OUTPUT_PATH Build-tree output path, normally containing $<CONFIG>.
+# @param TARGET_LIST_VARIABLE Name of the caller-owned sorted list of targets
+#   registered exactly once through gtest_discover_tests.
+# @return None; schedules one generated TSV per selected configuration.
+# @throws FATAL_ERROR If a target name contains unsafe manifest data, is not a
+#   legal local CMake target name, names a _NOT_BUILT sentinel, is missing, or
+#   is not an executable target.
+# @note Executable paths remain $<TARGET_FILE:...> generator expressions so
+#   single- and multi-config generators resolve the correct native path. The
+#   downstream parser validates the resolved field, including control bytes.
+function(photospider_generate_registered_gtest_target_inventory
+        OUTPUT_PATH TARGET_LIST_VARIABLE)
+    set(PHOTOSPIDER_GTEST_TARGET_INVENTORY_CONTENT
+        "# target\tconfigured executable\n")
+    set(PHOTOSPIDER_GTEST_TARGET_INDEX 0)
+    foreach(PHOTOSPIDER_REGISTERED_GTEST_TARGET
+            IN LISTS ${TARGET_LIST_VARIABLE})
+        math(EXPR PHOTOSPIDER_GTEST_TARGET_INDEX
+            "${PHOTOSPIDER_GTEST_TARGET_INDEX} + 1")
+        set(PHOTOSPIDER_GTEST_TARGET_CONTEXT
+            "Registered GoogleTest target entry ${PHOTOSPIDER_GTEST_TARGET_INDEX}")
+        _photospider_require_ci_inventory_field(
+            "${PHOTOSPIDER_GTEST_TARGET_CONTEXT}"
+            "${PHOTOSPIDER_REGISTERED_GTEST_TARGET}"
+            FALSE)
+        if(NOT "${PHOTOSPIDER_REGISTERED_GTEST_TARGET}" MATCHES
+                "^[A-Za-z0-9_.+-]+$" OR
+           "${PHOTOSPIDER_REGISTERED_GTEST_TARGET}" MATCHES "_NOT_BUILT$")
+            message(FATAL_ERROR
+                "${PHOTOSPIDER_GTEST_TARGET_CONTEXT} has an invalid CMake target name")
+        endif()
+        if(NOT TARGET "${PHOTOSPIDER_REGISTERED_GTEST_TARGET}")
+            message(FATAL_ERROR
+                "${PHOTOSPIDER_GTEST_TARGET_CONTEXT} does not name a target")
+        endif()
+        get_target_property(PHOTOSPIDER_GTEST_TARGET_TYPE
+            "${PHOTOSPIDER_REGISTERED_GTEST_TARGET}" TYPE)
+        if(NOT PHOTOSPIDER_GTEST_TARGET_TYPE STREQUAL "EXECUTABLE")
+            message(FATAL_ERROR
+                "${PHOTOSPIDER_GTEST_TARGET_CONTEXT} is not executable")
+        endif()
+        string(APPEND PHOTOSPIDER_GTEST_TARGET_INVENTORY_CONTENT
+            "${PHOTOSPIDER_REGISTERED_GTEST_TARGET}\t"
+            "$<TARGET_FILE:${PHOTOSPIDER_REGISTERED_GTEST_TARGET}>\n")
+    endforeach()
+
+    get_filename_component(PHOTOSPIDER_GTEST_TARGET_INVENTORY_DIRECTORY
+        "${OUTPUT_PATH}" DIRECTORY)
+    file(MAKE_DIRECTORY "${PHOTOSPIDER_GTEST_TARGET_INVENTORY_DIRECTORY}")
+    file(GENERATE OUTPUT "${OUTPUT_PATH}"
+        CONTENT "${PHOTOSPIDER_GTEST_TARGET_INVENTORY_CONTENT}")
+endfunction()

--- a/docs/CI/github-actions.md
+++ b/docs/CI/github-actions.md
@@ -98,15 +98,24 @@ self-containment invokes its dedicated compile target. These are durable
 product, package, configuration, and compile boundaries, not migration or
 source-layout checks. `OpenCvOperationProviderBuildSmokeSafety` remains an
 ordinary full-CTest safety regression for the OpenCV nested-build driver: its
-Python unittest exercises cleanup guards and cache-layout helpers in-process,
-but does not start a child configure, build, install, or compile target.
+Python unittest exercises cleanup guards and cache-layout helpers in-process.
+It also configures one compiler-free `project(... NONE)` fixture through the
+production manifest generator; it never starts a child build, install, compile
+target, or generated executable.
 
 Two nested-profile inventories remain exact without workflow-maintained counts.
 The static-product producer exports its configured CMake public-header install
 allowlist, and the consumer requires the installed include tree to equal those
-relative paths. The provider-disabled producer exports its active
-`gtest_discover_tests` targets with configuration-specific executable paths;
-after the focused build, the driver requires exactly the registered targets
+relative paths. Its CMake writer rejects backslashes and representable ASCII
+controls before serialization; its parser independently rejects all ASCII C0
+controls including NUL, plus DEL, and requires exact canonical POSIX install
+paths while preserving ordinary spaces.
+The provider-disabled producer exports its active `gtest_discover_tests`
+targets with configuration-specific executable paths through a TSV containing
+one exact header and strict two-field data lines. Later comments, blank lines,
+controls, extra fields, invalid or duplicate target names, and relative paths
+fail closed; absolute POSIX, Windows drive, and Windows UNC paths remain valid.
+After the focused build, the driver requires exactly the registered targets
 without executable files to appear as unlabelled `*_NOT_BUILT` placeholders.
 Both checks reject missing and extra entries, so a new allowlisted header or
 registered GoogleTest target changes the expectation through its authoritative

--- a/docs/CI/github-actions.md
+++ b/docs/CI/github-actions.md
@@ -101,6 +101,17 @@ ordinary full-CTest safety regression for the OpenCV nested-build driver: its
 Python unittest exercises cleanup guards and cache-layout helpers in-process,
 but does not start a child configure, build, install, or compile target.
 
+Two nested-profile inventories remain exact without workflow-maintained counts.
+The static-product producer exports its configured CMake public-header install
+allowlist, and the consumer requires the installed include tree to equal those
+relative paths. The provider-disabled producer exports its active
+`gtest_discover_tests` targets with configuration-specific executable paths;
+after the focused build, the driver requires exactly the registered targets
+without executable files to appear as unlabelled `*_NOT_BUILT` placeholders.
+Both checks reject missing and extra entries, so a new allowlisted header or
+registered GoogleTest target changes the expectation through its authoritative
+CMake declaration rather than a Python number or future-name special case.
+
 `build-integrity-default` builds the complete default profile once and uploads
 `ci-build-default`. The regular test jobs reuse that artifact:
 

--- a/docs/CI/zh/github-actions.zh.md
+++ b/docs/CI/zh/github-actions.zh.md
@@ -85,15 +85,21 @@ build profile；public-header self-containment 会调用专用 compile target。
 product、package、configuration 与 compile 边界，不是 migration 或 source-layout 检查。
 `OpenCvOperationProviderBuildSmokeSafety` 继续作为 OpenCV nested-build driver 的普通完整 CTest
 safety regression：其 Python unittest 会在进程内验证 cleanup guard 与 cache-layout helper，
-但不会启动 child configure、build、install 或 compile target。
+还会通过 production manifest generator 配置一个无需 compiler 的 `project(... NONE)` fixture；
+它不会启动 child build、install、compile target 或生成的 executable。
 
 两项 nested-profile inventory 无需在 workflow 中维护数量，也仍保持精确。Static-product producer
 会导出已配置的 CMake public-header install allowlist，consumer 要求已安装 include tree 与这些相对
-路径完全相等。Provider-disabled producer 会导出 active `gtest_discover_tests` target 及其配置专属
-executable 路径；focused build 完成后，driver 要求恰好只有那些不存在 executable file 的已注册
-target 表现为不带 label 的 `*_NOT_BUILT` 占位项。两项检查都会拒绝缺失和额外 entry，因此新增
-allowlisted header 或已注册 GoogleTest target 时，expectation 会通过其权威 CMake declaration
-变化，而不是依赖 Python 数字或针对未来名称的特判。
+路径完全相等。其 CMake writer 会在序列化前拒绝反斜杠与可表达的 ASCII control；parser 会独立
+拒绝包括 NUL 在内的全部 ASCII C0 control 以及 DEL，要求精确 canonical POSIX install path，
+同时保留普通空格。Provider-disabled producer 会通过只包含一个精确 header 与严格双字段 data
+line 的 TSV，导出 active
+`gtest_discover_tests` target 及其配置专属 executable 路径；后续 comment、空行、control、额外
+字段、非法或重复 target name 与相对路径都会 fail closed，绝对 POSIX path、Windows drive path
+与 Windows UNC path 仍然有效。Focused build 完成后，driver 要求恰好只有那些不存在 executable
+file 的已注册 target 表现为不带 label 的 `*_NOT_BUILT` 占位项。两项检查都会拒绝缺失和额外
+entry，因此新增 allowlisted header 或已注册 GoogleTest target 时，expectation 会通过其权威
+CMake declaration 变化，而不是依赖 Python 数字或针对未来名称的特判。
 
 `build-integrity-default` 会构建一次完整 default profile，并上传 `ci-build-default`。普通测试 job
 会复用该 artifact：

--- a/docs/CI/zh/github-actions.zh.md
+++ b/docs/CI/zh/github-actions.zh.md
@@ -87,6 +87,14 @@ product、package、configuration 与 compile 边界，不是 migration 或 sour
 safety regression：其 Python unittest 会在进程内验证 cleanup guard 与 cache-layout helper，
 但不会启动 child configure、build、install 或 compile target。
 
+两项 nested-profile inventory 无需在 workflow 中维护数量，也仍保持精确。Static-product producer
+会导出已配置的 CMake public-header install allowlist，consumer 要求已安装 include tree 与这些相对
+路径完全相等。Provider-disabled producer 会导出 active `gtest_discover_tests` target 及其配置专属
+executable 路径；focused build 完成后，driver 要求恰好只有那些不存在 executable file 的已注册
+target 表现为不带 label 的 `*_NOT_BUILT` 占位项。两项检查都会拒绝缺失和额外 entry，因此新增
+allowlisted header 或已注册 GoogleTest target 时，expectation 会通过其权威 CMake declaration
+变化，而不是依赖 Python 数字或针对未来名称的特判。
+
 `build-integrity-default` 会构建一次完整 default profile，并上传 `ci-build-default`。普通测试 job
 会复用该 artifact：
 

--- a/docs/development/Testing-and-Validation.md
+++ b/docs/development/Testing-and-Validation.md
@@ -109,6 +109,16 @@ archive, exported test target, or exported internal seam definition. This
 remains a labelled `build-smoke`; ordinary complete CTest selection does not
 make package construction part of runtime-test ownership.
 
+The configured producer also serializes
+`PHOTOSPIDER_INSTALLABLE_PUBLIC_HEADER_RELATIVE_PATHS` into a build-tree
+inventory using install-relative `include/photospider/...` paths. The smoke
+rejects a missing, empty, duplicate, noncanonical, or non-header entry, generates
+the external consumer's include list from that inventory, and requires the
+installed include tree to equal the configured path set. Missing and unexpected
+files therefore fail the same exact comparison; neither the driver nor the
+documentation maintains a second public-header count, and an unallowlisted
+source-tree file cannot silently widen the package surface.
+
 The smoke inspects every installed `Photospider*Targets*.cmake` file because
 the package separates base, OpenCV-dependent, and embedded-product targets
 into distinct export sets. Its dependency classifier recognizes only the exact
@@ -849,16 +859,28 @@ the public ABI.
 `PHOTOSPIDER_BUILD_OPENCV_OPERATION_PROVIDER=OFF`, while OpenCV, YAML, graph
 CLI, and operation-plugin defaults remain enabled. The provider-aware broad
 suite gate is therefore off. The driver validates the exact CMake cache
-profile, builds the provider-independent focused provider binary, its
-stdlib-only fixture, and the dedicated disk-cache diagnostic concurrency binary,
-then queries the machine-readable CTest inventory. That inventory must contain
-exactly `DependencyDisabledInstallSmoke`,
-`OptionalOpenCvOperationProvider.ReplacementExecutesAndRestores`, and the three
-`DiskCacheDiagnosticConcurrency.*` cases; every concurrency case must retain
-only the `kernel-concurrency` label and its 20-second timeout. No broad
-provider-dependent test may remain registered. The driver runs the optional
-provider case and all three concurrency cases through CTest. The disabled
-profile requires dependency-neutral
+profile, builds the provider-independent focused provider binary and its
+stdlib-only fixture, plus the dedicated disk-cache diagnostic and kernel-
+lifecycle concurrency binaries, then queries the machine-readable CTest
+inventory.
+
+During configuration, CMake serializes every active `gtest_discover_tests`
+target and its configuration-specific `$<TARGET_FILE:...>` path after
+cross-checking the GoogleTest registration metadata. After the focused build,
+the driver derives the exact unlabelled `${target}_NOT_BUILT` set from registered
+targets whose executable is not a regular file. This observes the real build
+closure, including indirect dependencies, without hard-coding a target count or
+future target name and without deriving expectations from CTest's observed
+sentinels. The exact CTest inventory is the union of that derived set and
+`DependencyDisabledInstallSmoke`,
+`OptionalOpenCvOperationProvider.ReplacementExecutesAndRestores`, the three
+`DiskCacheDiagnosticConcurrency.*` cases, and the two
+`KernelLifecycleConcurrency.*` cases. Derived sentinels must carry no label or
+timeout; disk-cache cases retain only the `kernel-concurrency` label and their
+20-second timeout, while lifecycle cases retain that label and their 60-second
+timeout. Missing or extra entries fail, so no provider-dependent broad test may
+remain registered. The driver runs the optional-provider and all concurrency
+cases through CTest. The disabled profile requires dependency-neutral
 analyzer/math operations to remain seeded, OpenCV-backed operation keys to be
 absent, and the replacement provider to publish, execute, and fully retire its
 resize key. The transient build is a long-lived product configuration check;

--- a/docs/development/Testing-and-Validation.md
+++ b/docs/development/Testing-and-Validation.md
@@ -111,13 +111,26 @@ make package construction part of runtime-test ownership.
 
 The configured producer also serializes
 `PHOTOSPIDER_INSTALLABLE_PUBLIC_HEADER_RELATIVE_PATHS` into a build-tree
-inventory using install-relative `include/photospider/...` paths. The smoke
-rejects a missing, empty, duplicate, noncanonical, or non-header entry, generates
-the external consumer's include list from that inventory, and requires the
-installed include tree to equal the configured path set. Missing and unexpected
-files therefore fail the same exact comparison; neither the driver nor the
-documentation maintains a second public-header count, and an unallowlisted
-source-tree file cannot silently widen the package surface.
+inventory using install-relative `include/photospider/...` paths. Before it
+writes any record, the CMake 3.16-compatible writer rejects a backslash, every
+CMake-representable ASCII C0 control (codes 1 through 31), and DEL; diagnostics
+identify the allowlist position without reproducing the rejected field.
+CMake strings cannot represent NUL, so the reader independently rejects all
+C0 controls including NUL, plus DEL, in a forged or externally modified
+manifest. LF is the only record separator. Ordinary spaces remain legal POSIX
+path data.
+
+The smoke rejects a missing, empty, duplicate, control-bearing, backslash-
+bearing, noncanonical, or non-header entry. It applies an exact
+`PurePosixPath` spelling/root/suffix check before generating the external
+consumer's include list, then requires the installed include tree to equal the
+configured path set. Missing and unexpected files therefore fail the same
+exact comparison; neither the driver nor the documentation maintains a second
+public-header count, and an unallowlisted source-tree file cannot silently
+widen the package surface. The safety regression round-trips an ordinary-space
+path through the production CMake writer and parser, and proves that every
+CMake-representable control and both parent-like and ordinary backslash paths
+fail before serialization.
 
 The smoke inspects every installed `Photospider*Targets*.cmake` file because
 the package separates base, OpenCV-dependent, and embedded-product targets
@@ -207,8 +220,10 @@ A build smoke is a durable CTest whose primary boundary delegates to a CMake
 configure/build/install, an exported-package or external-consumer build, or a
 dedicated compile target. Every such test carries the exact stable CTest label
 `build-smoke`. A companion that only calls the driver's Python cleanup or
-layout helpers in-process remains an ordinary safety regression in the full
-CTest shard.
+layout helpers, or configures a compiler-free manifest-generation fixture,
+remains an ordinary safety regression in the full CTest shard when it does not
+delegate to a product build, install, external consumer, compile target, or
+generated executable.
 
 The maintained labelled inventory is
 `DependencyDisabledInstallSmoke`,
@@ -221,20 +236,23 @@ CTest command builds the dedicated self-containment target; ordinary
 GoogleTest binaries, daemon/CLI process tests, and
 `PhotospiderdCapabilityHelp` do not create a child build and remain in the main
 CTest shard. `OpenCvOperationProviderBuildSmokeSafety` also remains there: it
-is the ordinary safety regression for the OpenCV build-smoke driver and does
-not itself start CMake, CTest, an install, or a compile target.
+is the ordinary safety regression for the OpenCV build-smoke driver. Its one
+`project(... NONE)` fixture exercises the production manifest generator with
+an imported executable, but starts no compiler, product build, CTest, install,
+compile target, or generated executable.
 `InstallConsumerArchitecturePropagationSafety` likewise remains in the main
 shard: it runs the three install-consumer drivers' real command-construction
 paths against disposable producer cache fixtures while replacing subprocess
 execution, so it verifies cache-to-child-argv propagation without launching a
-configure, build, or install. The same process injects executable lookup,
-validation, and captured-command callbacks into the static-product driver's
-production archive-symbol helpers. It locks Darwin xcrun-first fallback,
-non-Darwin independence, all-candidate failure, and canonical path
-de-duplication without changing process PATH or replacing the real installed
-archive scan. When CMake registers the safety test, it also supplies the
-current build tree, CTest executable, configuration, and Python launcher. The
-test queries that tree through
+product configure, build, or install. A separate `cmake -P` fixture calls the
+production public-header writer directly and performs no project configure.
+The same process injects executable lookup, validation, and captured-command
+callbacks into the static-product driver's production archive-symbol helpers.
+It locks Darwin xcrun-first fallback, non-Darwin independence, all-candidate
+failure, and canonical path de-duplication without changing process PATH or
+replacing the real installed archive scan. When CMake registers the safety
+test, it also supplies the current build tree, CMake and CTest executables,
+configuration, and Python launcher. The test queries that tree through
 `ctest --show-only=json-v1` and the production inventory parser. It requires
 `DependencyDisabledInstallSmoke` and `IpcDisabledInstallSmoke` exactly once in
 every profile, requires `StaticProductConsumerSmoke` exactly once only when
@@ -866,12 +884,24 @@ inventory.
 
 During configuration, CMake serializes every active `gtest_discover_tests`
 target and its configuration-specific `$<TARGET_FILE:...>` path after
-cross-checking the GoogleTest registration metadata. After the focused build,
-the driver derives the exact unlabelled `${target}_NOT_BUILT` set from registered
-targets whose executable is not a regular file. This observes the real build
-closure, including indirect dependencies, without hard-coding a target count or
-future target name and without deriving expectations from CTest's observed
-sentinels. The exact CTest inventory is the union of that derived set and
+cross-checking the GoogleTest registration metadata. The generated TSV has one
+exact first-line header, `# target<TAB>configured executable`, followed only by
+nonempty two-field data records. The CMake writer accepts only local executable
+target names composed of letters, digits, `_`, `.`, `+`, and `-`, while keeping
+`$<TARGET_FILE:...>` and `$<CONFIG>` unevaluated until generation so single-
+and multi-config builds select the native executable path. The reader rejects a
+missing or repeated header, every later comment or blank line, an extra field,
+a duplicate target, `_NOT_BUILT` input, and every non-structural C0 control or
+DEL. NUL remains reader-rejected even though CMake cannot represent it. Target
+paths must be lexically absolute POSIX paths, Windows drive-rooted paths, or
+Windows UNC paths; ordinary spaces and Windows backslashes are valid data.
+
+After the focused build, the driver derives the exact unlabelled
+`${target}_NOT_BUILT` set from registered targets whose executable is not a
+regular file. This observes the real build closure, including indirect
+dependencies, without hard-coding a target count or future target name and
+without deriving expectations from CTest's observed sentinels. The exact CTest
+inventory is the union of that derived set and
 `DependencyDisabledInstallSmoke`,
 `OptionalOpenCvOperationProvider.ReplacementExecutesAndRestores`, the three
 `DiskCacheDiagnosticConcurrency.*` cases, and the two

--- a/docs/development/zh/Testing-and-Validation.zh.md
+++ b/docs/development/zh/Testing-and-Validation.zh.md
@@ -81,6 +81,13 @@ observations。Smoke 也会拒绝已安装的 test product archive、已导出�
 seam definition。该测试继续属于带 label 的 `build-smoke`；普通完整 CTest selection 不会让
 package construction 混入 runtime-test ownership。
 
+配置后的 producer 还会把 `PHOTOSPIDER_INSTALLABLE_PUBLIC_HEADER_RELATIVE_PATHS` 序列化为
+build-tree inventory，其中使用安装相对路径 `include/photospider/...`。Smoke 会拒绝缺失、空、
+重复、非 canonical 或非 header 的 entry，从该 inventory 生成 external consumer 的 include 清单，
+并要求已安装 include tree 与配置得到的路径集合完全相等。因此缺失文件与意外文件都会在同一项
+精确比较中失败；driver 和文档均不维护第二份 public-header 数量，未进入 allowlist 的 source-tree
+文件也无法静默扩大 package surface。
+
 该 smoke 会检查每个已安装的 `Photospider*Targets*.cmake` 文件，因为 package 将基础 target、
 依赖 OpenCV 的 target 与 embedded-product target 分到不同 export set 中。它的 dependency
 classifier 只识别 producer 接受的精确 OpenCV component target 拼写：裸 lowercase name、lowercase
@@ -673,19 +680,26 @@ tiled exception wrapper。两次相互独立的 `cv::Error::StsNoMem` 注入都�
 `OpenCvOperationProviderDisabledBuild` 会使用
 `BUILD_TESTING=ON` 与 `PHOTOSPIDER_BUILD_OPENCV_OPERATION_PROVIDER=OFF`
 配置一个临时嵌套 build，同时保留 OpenCV、YAML、graph CLI 与 operation-plugin 的默认启用值。
-因此 provider-aware broad suite gate 为关闭。Driver 会校验精确 CMake cache 画像，构建上述
-provider-independent focused binary 与 stdlib-only fixture，并额外构建专用 disk-cache
-diagnostic concurrency binary，再查询机器可读的 CTest inventory。该 inventory 必须精确包含
-`DependencyDisabledInstallSmoke`、
-`OptionalOpenCvOperationProvider.ReplacementExecutesAndRestores` 与三个
-`DiskCacheDiagnosticConcurrency.*` case；每个 concurrency case 必须仅保留
-`kernel-concurrency` label 与 20 秒 timeout。不得残留任何依赖 provider 的 broad test。
-Driver 随后通过 CTest 运行 optional-provider case 与全部三个 concurrency case。禁用
-profile 要求依赖中立
-analyzer/math operation 仍被 seed、OpenCV-backed operation key 不存在，并要求 replacement
-provider 能发布、执行且完整退役其 resize key。该临时 build 是长期 product configuration
-检查；它把命令与结果写入 CTest，不保留逐次运行报告。当前阶段禁用的是 operation provider，
-不是彼此独立的 OpenCV codec、normalization、adapter 或 embedded-product 依赖。
+因此 provider-aware broad suite gate 为关闭。Driver 会校验精确 CMake cache 画像，构建
+provider-independent focused provider binary 及其 stdlib-only fixture，并额外构建专用 disk-cache
+diagnostic 与 kernel-lifecycle concurrency binary，再查询机器可读的 CTest inventory。
+
+配置期间，CMake 会在交叉核验 GoogleTest registration metadata 后，序列化每个 active
+`gtest_discover_tests` target 及其配置专属 `$<TARGET_FILE:...>` 路径。Focused build 完成后，
+driver 会从 executable 不是 regular file 的已注册 target 推导精确且不带 label 的
+`${target}_NOT_BUILT` 集合。该过程会观察真实 build closure（包括间接 dependency），无需硬编码
+target 数量或未来 target 名，也不会从 CTest 实际观察到的 sentinel 反推 expectation。精确 CTest
+inventory 等于该推导集合与以下条目的并集：`DependencyDisabledInstallSmoke`、
+`OptionalOpenCvOperationProvider.ReplacementExecutesAndRestores`、三个
+`DiskCacheDiagnosticConcurrency.*` case，以及两个 `KernelLifecycleConcurrency.*` case。推导出的
+sentinel 不得带 label 或 timeout；disk-cache case 必须仅保留 `kernel-concurrency` label 与 20 秒
+timeout，lifecycle case 则保留同一 label 与 60 秒 timeout。缺失或额外 entry 都会失败，因此不得
+残留任何依赖 provider 的 broad test。Driver 随后通过 CTest 运行 optional-provider case 与全部
+concurrency case。禁用 profile 要求依赖中立 analyzer/math operation 仍被 seed、OpenCV-backed
+operation key 不存在，并要求 replacement provider 能发布、执行且完整退役其 resize key。该临时
+build 是长期 product configuration 检查；它把命令与结果写入 CTest，不保留逐次运行报告。当前
+阶段禁用的是 operation provider，不是彼此独立的 OpenCV codec、normalization、adapter 或
+embedded-product 依赖。
 
 OpenCV-provider 与注入式 codec 两个嵌套 build driver 都从
 `cmake_build_smoke_support.py` 导入同一份破坏性 work-tree helper。移除临时目录前，该 helper

--- a/docs/development/zh/Testing-and-Validation.zh.md
+++ b/docs/development/zh/Testing-and-Validation.zh.md
@@ -82,11 +82,19 @@ seam definition。该测试继续属于带 label 的 `build-smoke`；普通完�
 package construction 混入 runtime-test ownership。
 
 配置后的 producer 还会把 `PHOTOSPIDER_INSTALLABLE_PUBLIC_HEADER_RELATIVE_PATHS` 序列化为
-build-tree inventory，其中使用安装相对路径 `include/photospider/...`。Smoke 会拒绝缺失、空、
-重复、非 canonical 或非 header 的 entry，从该 inventory 生成 external consumer 的 include 清单，
-并要求已安装 include tree 与配置得到的路径集合完全相等。因此缺失文件与意外文件都会在同一项
-精确比较中失败；driver 和文档均不维护第二份 public-header 数量，未进入 allowlist 的 source-tree
-文件也无法静默扩大 package surface。
+build-tree inventory，其中使用安装相对路径 `include/photospider/...`。写入任何 record 前，
+兼容 CMake 3.16 的 writer 会拒绝反斜杠、CMake 可以表达的全部 ASCII C0 control（code 1 至 31）
+与 DEL；diagnostic 只标识 allowlist 位置，不复述被拒绝字段。CMake string 无法表达 NUL，因此
+reader 会独立拒绝伪造或被外部修改的 manifest 中包括 NUL 在内的全部 C0 control 以及 DEL。
+LF 是唯一的 record separator；普通空格仍是合法的 POSIX path 数据。
+
+Smoke 会拒绝缺失、空、重复、含 control、含反斜杠、非 canonical 或非 header 的 entry。
+它先执行精确的 `PurePosixPath` 拼写/root/suffix 检查，再从该 inventory 生成 external consumer
+的 include 清单，并要求已安装 include tree 与配置得到的路径集合完全相等。因此缺失文件与
+意外文件都会在同一项精确比较中失败；driver 和文档均不维护第二份 public-header 数量，
+未进入 allowlist 的 source-tree 文件也无法静默扩大 package surface。Safety regression 会让
+带普通空格的路径经过真实 CMake writer 与 parser 往返，并证明 CMake 可表达的每个 control、
+形似 parent 的反斜杠路径与普通反斜杠路径都会在序列化前失败。
 
 该 smoke 会检查每个已安装的 `Photospider*Targets*.cmake` 文件，因为 package 将基础 target、
 依赖 OpenCV 的 target 与 embedded-product target 分到不同 export set 中。它的 dependency
@@ -155,7 +163,9 @@ Issue 专属 replay、provenance、helper 和 output artifact 既不得进入 pr
 Build smoke 是一种长期维护的 CTest，其主要边界会委托执行 CMake configure/build/install、
 exported package 或 external consumer build，或者专用 compile target。所有此类测试都携带精确且
 稳定的 CTest 标签 `build-smoke`。如果 companion 只在进程内调用 driver 的 Python cleanup 或 layout
-helper，它会作为普通 safety regression 留在完整 CTest 分片。
+helper，或者配置一个不需要 compiler 的 manifest-generation fixture，并且没有委托执行 product
+build、install、external consumer、compile target 或生成的 executable，它仍会作为普通 safety
+regression 留在完整 CTest 分片。
 
 当前带标签的 inventory 是
 `DependencyDisabledInstallSmoke`、
@@ -167,15 +177,19 @@ helper，它会作为普通 safety regression 留在完整 CTest 分片。
 会构建专用 self-containment target；普通 GoogleTest binary、daemon/CLI process test 与
 `PhotospiderdCapabilityHelp` 不会创建 child build，因此继续留在主 CTest 分片。
 `OpenCvOperationProviderBuildSmokeSafety` 也留在该分片：它是 OpenCV build-smoke driver 的普通
-safety regression，本身不会启动 CMake、CTest、install 或 compile target。
+safety regression。其唯一的 `project(... NONE)` fixture 会使用 imported executable 执行 production
+manifest generator，但不会启动 compiler、product build、CTest、install、compile target 或生成的
+executable。
 `InstallConsumerArchitecturePropagationSafety` 同样留在主分片：它使用可丢弃的 producer cache
 fixture 执行三个 install-consumer driver 的真实命令构造路径，同时替换 subprocess 执行，因此能
-在不启动 configure、build 或 install 的情况下验证 cache 到 child argv 的传播。同一进程还会向
-static-product driver 的 production archive-symbol helper 注入 executable lookup、validation 与
-captured-command callback；它会在不改变进程 PATH、也不取代真实 installed archive scan 的前提下，
-锁定 Darwin xcrun-first fallback、非 Darwin 独立性、全部 candidate failure 与 canonical path
-去重。CMake 注册该 safety test 时，还会传入当前 build tree、CTest executable、configuration 与
-Python launcher。测试随后通过 `ctest --show-only=json-v1` 和生产 inventory parser 查询该 build
+在不启动 product configure、build 或 install 的情况下验证 cache 到 child argv 的传播。另一项
+`cmake -P` fixture 会直接调用 production public-header writer，并且不会执行 project configure。
+同一进程还会向 static-product driver 的 production archive-symbol helper 注入 executable lookup、
+validation 与 captured-command callback；它会在不改变进程 PATH、也不取代真实 installed archive
+scan 的前提下，锁定 Darwin xcrun-first fallback、非 Darwin 独立性、全部 candidate failure 与
+canonical path 去重。CMake 注册该 safety test 时，还会传入当前 build tree、CMake 与 CTest
+executable、configuration 与 Python launcher。测试随后通过 `ctest --show-only=json-v1` 和生产
+inventory parser 查询该 build
 tree，并要求三个
 真实 smoke 遵循配置相关的精确集合：所有 profile 都必须各自只注册一次
 `DependencyDisabledInstallSmoke` 与 `IpcDisabledInstallSmoke`；
@@ -685,10 +699,19 @@ provider-independent focused provider binary 及其 stdlib-only fixture，并额
 diagnostic 与 kernel-lifecycle concurrency binary，再查询机器可读的 CTest inventory。
 
 配置期间，CMake 会在交叉核验 GoogleTest registration metadata 后，序列化每个 active
-`gtest_discover_tests` target 及其配置专属 `$<TARGET_FILE:...>` 路径。Focused build 完成后，
-driver 会从 executable 不是 regular file 的已注册 target 推导精确且不带 label 的
-`${target}_NOT_BUILT` 集合。该过程会观察真实 build closure（包括间接 dependency），无需硬编码
-target 数量或未来 target 名，也不会从 CTest 实际观察到的 sentinel 反推 expectation。精确 CTest
+`gtest_discover_tests` target 及其配置专属 `$<TARGET_FILE:...>` 路径。生成的 TSV 只允许一个
+精确首行 header `# target<TAB>configured executable`，其后只能出现非空的双字段 data record。
+CMake writer 只接受由字母、数字、`_`、`.`、`+` 与 `-` 组成的 local executable target name，
+同时保留 `$<TARGET_FILE:...>` 与 `$<CONFIG>`，直到 generation 阶段才求值，因此 single-config
+与 multi-config build 都会选择原生 executable path。Reader 会拒绝缺失或重复的 header、
+后续任何 comment 或空行、额外字段、重复 target、输入的 `_NOT_BUILT`，以及所有非结构性 C0
+control 与 DEL；即使 CMake 无法表达 NUL，reader 仍会拒绝它。Target path 必须在词法上是绝对
+POSIX path、Windows drive-rooted path 或 Windows UNC path；普通空格与 Windows 反斜杠是合法数据。
+
+Focused build 完成后，driver 会从 executable 不是 regular file 的已注册 target 推导精确且
+不带 label 的 `${target}_NOT_BUILT` 集合。该过程会观察真实 build closure（包括间接
+dependency），无需硬编码 target 数量或未来 target 名，也不会从 CTest 实际观察到的 sentinel
+反推 expectation。精确 CTest
 inventory 等于该推导集合与以下条目的并集：`DependencyDisabledInstallSmoke`、
 `OptionalOpenCvOperationProvider.ReplacementExecutesAndRestores`、三个
 `DiskCacheDiagnosticConcurrency.*` case，以及两个 `KernelLifecycleConcurrency.*` case。推导出的

--- a/tests/integration/install_consumer_architecture_propagation_test.py
+++ b/tests/integration/install_consumer_architecture_propagation_test.py
@@ -38,6 +38,12 @@ BUILD_SMOKE_INVENTORY_MODULE_PATH = (
 BUILD_SMOKE_INVENTORY_MODULE_NAME = (
     "_photospider_install_consumer_build_smoke_inventory"
 )
+#: @brief Production CMake module that owns both CI manifest writers.
+#: @note Safety tests execute this exact module in script mode rather than
+#:   reproducing its serialization or validation rules in Python.
+CI_INVENTORY_CMAKE_MODULE_PATH = (
+    REPOSITORY_ROOT / "cmake" / "PhotospiderCiInventory.cmake"
+)
 #: @brief Import specification for the production CTest inventory parser.
 #: @note The loader releases its source file after synchronous module execution.
 BUILD_SMOKE_INVENTORY_SPEC = importlib.util.spec_from_file_location(
@@ -59,6 +65,21 @@ ctest_inventory = importlib.util.module_from_spec(
 )
 sys.modules[BUILD_SMOKE_INVENTORY_MODULE_NAME] = ctest_inventory
 BUILD_SMOKE_INVENTORY_SPEC.loader.exec_module(ctest_inventory)
+
+
+def write_exact_text(path: pathlib.Path, text: str) -> None:
+    """@brief Write UTF-8 fixture text without native newline translation.
+
+    @param path Existing-parent destination owned by the current test.
+    @param text Exact manifest or CMake script bytes to serialize as UTF-8.
+    @return None after the file is closed successfully.
+    @throws OSError If the fixture file cannot be opened or written.
+    @note Explicit ``newline=''`` keeps LF/CR injection cases identical on
+      Python 3.9 and later across POSIX and Windows hosts.
+    """
+
+    with path.open("w", encoding="utf-8", newline="") as output_file:
+        output_file.write(text)
 
 
 #: @brief Module-owned multi-architecture CMake cache fixture for all cases.
@@ -305,6 +326,7 @@ def parse_live_inventory_arguments(
 
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--build-dir", type=pathlib.Path)
+    parser.add_argument("--cmake-executable", default="cmake")
     parser.add_argument("--ctest-executable", default="ctest")
     parser.add_argument("--config")
     parser.add_argument("--python-executable")
@@ -591,12 +613,20 @@ class SymbolToolHarness:
 class ConfiguredPublicHeaderInventoryTest(unittest.TestCase):
     """@brief Validate CMake-derived package header inventory parsing.
 
-    @throws OSError If a disposable inventory cannot be created or read.
+    @throws OSError If a disposable inventory cannot be created or read, or if
+      the configured CMake executable cannot start.
+    @throws subprocess.CalledProcessError If the production CMake writer rejects
+      a valid fixture.
     @throws AssertionError If valid exact paths drift or malformed entries are
       accepted.
-    @note Tests use only synthetic build trees and never configure or install
-      the repository product.
+    @note Tests use only synthetic build trees. One case launches the exact
+      production writer in CMake script mode; no product configure, compiler,
+      build, install, or executable is involved.
     """
+
+    #: @brief CMake launcher used only for the production writer safety case.
+    #: @note CTest supplies CMAKE_COMMAND; direct unittest execution uses PATH.
+    cmake_executable: str = "cmake"
 
     def test_loads_exact_sorted_public_header_includes(self) -> None:
         """@brief Convert the configured allowlist into consumer includes.
@@ -618,17 +648,19 @@ class ConfiguredPublicHeaderInventoryTest(unittest.TestCase):
                 / static_product.PUBLIC_HEADER_INVENTORY_RELATIVE_PATH
             )
             manifest.parent.mkdir(parents=True)
-            manifest.write_text(
+            write_exact_text(
+                manifest,
                 "include/photospider/plugin/plugin_api.hpp\n"
                 "include/photospider/data/arbitrary_future_value.hpp\n"
+                "include/photospider/data/path with space.hpp\n"
                 "include/photospider/policy/policy_plugin_api.h\n",
-                encoding="utf-8",
             )
 
             self.assertEqual(
                 static_product.public_header_includes(build),
                 [
                     "#include <photospider/data/arbitrary_future_value.hpp>",
+                    "#include <photospider/data/path with space.hpp>",
                     "#include <photospider/plugin/plugin_api.hpp>",
                     "#include <photospider/policy/policy_plugin_api.h>",
                 ],
@@ -658,27 +690,144 @@ class ConfiguredPublicHeaderInventoryTest(unittest.TestCase):
                 static_product.public_header_includes(build)
 
             manifest.parent.mkdir(parents=True)
-            malformed_payloads = (
-                "",
-                "include/other/header.hpp\n",
-                "include/photospider/../header.hpp\n",
-                "include/photospider/header.cpp\n",
-                (
+            malformed_payloads = {
+                "empty": "",
+                "wrong-root": "include/other/header.hpp\n",
+                "posix-parent": "include/photospider/../header.hpp\n",
+                "backslash-parent": (
+                    "include/photospider/..\\outside.hpp\n"
+                ),
+                "backslash-path": (
+                    "include/photospider/folder\\header.hpp\n"
+                ),
+                "wrong-suffix": "include/photospider/header.cpp\n",
+                "duplicate": (
                     "include/photospider/header.hpp\n"
                     "include/photospider/header.hpp\n"
                 ),
-                (
+                "blank-line": (
                     "include/photospider/header.hpp\n\n"
                     "include/photospider/other.hpp\n"
                 ),
+                "delete": "include/photospider/del\x7fheader.hpp\n",
+            }
+            malformed_payloads.update(
+                {
+                    f"c0-{control_code}": (
+                        "include/photospider/control"
+                        f"{chr(control_code)}header.hpp\n"
+                    )
+                    for control_code in range(32)
+                }
             )
-            for payload in malformed_payloads:
-                with self.subTest(payload=payload):
-                    manifest.write_text(payload, encoding="utf-8")
+            for case_name, payload in malformed_payloads.items():
+                with self.subTest(case=case_name):
+                    write_exact_text(manifest, payload)
                     with self.assertRaisesRegex(
                         RuntimeError, "public-header inventory"
                     ):
                         static_product.public_header_includes(build)
+
+    def test_cmake_writer_rejects_unsafe_fields_before_serialization(
+        self,
+    ) -> None:
+        """@brief Exercise the production CMake writer's field boundary.
+
+        @return None after one ordinary-space POSIX path round-trips through the
+          real writer/parser and every backslash or representable control case
+          fails before a manifest is created.
+        @throws OSError If the script fixture cannot be written or CMake cannot
+          start.
+        @throws subprocess.CalledProcessError If the valid writer invocation
+          fails.
+        @throws AssertionError If CMake accepts an unsafe field, leaks it in the
+          diagnostic, or the real parser rejects the safe generated manifest.
+        @note C0 codes 1 through 31 and DEL are representable by CMake. NUL is
+          exercised only at the Python reader boundary because neither CMake
+          strings nor subprocess argv can carry it.
+        """
+
+        with tempfile.TemporaryDirectory(
+            prefix="photospider-public-header-cmake-writer-"
+        ) as temporary:
+            sandbox = pathlib.Path(temporary)
+            script = sandbox / "write_public_header_inventory.cmake"
+            write_exact_text(
+                script,
+                "cmake_minimum_required(VERSION 3.16)\n"
+                f'include("{CI_INVENTORY_CMAKE_MODULE_PATH.as_posix()}")\n'
+                "set(PHOTOSPIDER_TEST_PUBLIC_HEADERS "
+                '"${PHOTOSPIDER_TEST_PUBLIC_HEADER}")\n'
+                "photospider_write_public_header_inventory(\n"
+                '  "${PHOTOSPIDER_TEST_OUTPUT}"\n'
+                "  PHOTOSPIDER_TEST_PUBLIC_HEADERS)\n",
+            )
+
+            safe_build = sandbox / "safe build"
+            safe_manifest = (
+                safe_build
+                / static_product.PUBLIC_HEADER_INVENTORY_RELATIVE_PATH
+            )
+            subprocess.run(
+                [
+                    self.cmake_executable,
+                    (
+                        "-DPHOTOSPIDER_TEST_PUBLIC_HEADER="
+                        "data/path with space.hpp"
+                    ),
+                    f"-DPHOTOSPIDER_TEST_OUTPUT={safe_manifest}",
+                    "-P",
+                    str(script),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(
+                static_product.public_header_includes(safe_build),
+                ["#include <photospider/data/path with space.hpp>"],
+            )
+
+            unsafe_fields = {
+                "backslash-parent": "..\\outside.hpp",
+                "backslash-path": "folder\\header.hpp",
+                "delete": "del\x7fheader.hpp",
+                **{
+                    f"c0-{control_code}": (
+                        f"control{chr(control_code)}header.hpp"
+                    )
+                    for control_code in range(1, 32)
+                },
+            }
+            for case_name, unsafe_field in unsafe_fields.items():
+                with self.subTest(case=case_name):
+                    rejected_manifest = (
+                        sandbox
+                        / case_name
+                        / static_product.PUBLIC_HEADER_INVENTORY_RELATIVE_PATH
+                    )
+                    result = subprocess.run(
+                        [
+                            self.cmake_executable,
+                            (
+                                "-DPHOTOSPIDER_TEST_PUBLIC_HEADER="
+                                f"{unsafe_field}"
+                            ),
+                            f"-DPHOTOSPIDER_TEST_OUTPUT={rejected_manifest}",
+                            "-P",
+                            str(script),
+                        ],
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertRegex(
+                        result.stderr,
+                        r"forbidden (?:backslash|ASCII control code)",
+                    )
+                    self.assertNotIn(unsafe_field, result.stderr)
+                    self.assertFalse(rejected_manifest.exists())
 
 
 class InstallConsumerCTestRegistrationTest(unittest.TestCase):
@@ -1855,6 +2004,9 @@ class InstallConsumerArchitecturePropagationTest(unittest.TestCase):
 if __name__ == "__main__":
     live_options, forwarded_unittest_argv = (
         parse_live_inventory_arguments(sys.argv)
+    )
+    ConfiguredPublicHeaderInventoryTest.cmake_executable = (
+        live_options.cmake_executable
     )
     InstallConsumerCTestRegistrationTest.live_build_dir = (
         live_options.build_dir

--- a/tests/integration/install_consumer_architecture_propagation_test.py
+++ b/tests/integration/install_consumer_architecture_propagation_test.py
@@ -588,6 +588,99 @@ class SymbolToolHarness:
         return [command[0] for command in self.run_commands]
 
 
+class ConfiguredPublicHeaderInventoryTest(unittest.TestCase):
+    """@brief Validate CMake-derived package header inventory parsing.
+
+    @throws OSError If a disposable inventory cannot be created or read.
+    @throws AssertionError If valid exact paths drift or malformed entries are
+      accepted.
+    @note Tests use only synthetic build trees and never configure or install
+      the repository product.
+    """
+
+    def test_loads_exact_sorted_public_header_includes(self) -> None:
+        """@brief Convert the configured allowlist into consumer includes.
+
+        @return None after unsorted CMake entries become a sorted exact include
+          inventory with no count-specific expectation.
+        @throws OSError If the synthetic manifest cannot be written.
+        @throws AssertionError If path conversion loses or invents an entry.
+        @note The fixture deliberately uses an arbitrary new header name to
+          prove that the parser is driven by the configured allowlist.
+        """
+
+        with tempfile.TemporaryDirectory(
+            prefix="photospider-public-header-inventory-"
+        ) as temporary:
+            build = pathlib.Path(temporary) / "build"
+            manifest = (
+                build
+                / static_product.PUBLIC_HEADER_INVENTORY_RELATIVE_PATH
+            )
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                "include/photospider/plugin/plugin_api.hpp\n"
+                "include/photospider/data/arbitrary_future_value.hpp\n"
+                "include/photospider/policy/policy_plugin_api.h\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                static_product.public_header_includes(build),
+                [
+                    "#include <photospider/data/arbitrary_future_value.hpp>",
+                    "#include <photospider/plugin/plugin_api.hpp>",
+                    "#include <photospider/policy/policy_plugin_api.h>",
+                ],
+            )
+
+    def test_rejects_missing_or_malformed_public_header_inventory(
+        self,
+    ) -> None:
+        """@brief Reject absent, empty, duplicate, and unsafe manifest entries.
+
+        @return None after every fail-closed counterexample raises RuntimeError.
+        @throws OSError If a synthetic malformed manifest cannot be written.
+        @throws AssertionError If any malformed inventory is accepted.
+        @note The fixtures cover exact-root, canonical-path, suffix, duplicate,
+          and nonempty constraints without accessing repository headers.
+        """
+
+        with tempfile.TemporaryDirectory(
+            prefix="photospider-public-header-invalid-"
+        ) as temporary:
+            build = pathlib.Path(temporary) / "build"
+            manifest = (
+                build
+                / static_product.PUBLIC_HEADER_INVENTORY_RELATIVE_PATH
+            )
+            with self.assertRaisesRegex(RuntimeError, "is missing"):
+                static_product.public_header_includes(build)
+
+            manifest.parent.mkdir(parents=True)
+            malformed_payloads = (
+                "",
+                "include/other/header.hpp\n",
+                "include/photospider/../header.hpp\n",
+                "include/photospider/header.cpp\n",
+                (
+                    "include/photospider/header.hpp\n"
+                    "include/photospider/header.hpp\n"
+                ),
+                (
+                    "include/photospider/header.hpp\n\n"
+                    "include/photospider/other.hpp\n"
+                ),
+            )
+            for payload in malformed_payloads:
+                with self.subTest(payload=payload):
+                    manifest.write_text(payload, encoding="utf-8")
+                    with self.assertRaisesRegex(
+                        RuntimeError, "public-header inventory"
+                    ):
+                        static_product.public_header_includes(build)
+
+
 class InstallConsumerCTestRegistrationTest(unittest.TestCase):
     """@brief Lock active CTest commands for the three real install smokes.
 

--- a/tests/integration/optional_opencv_operation_provider_build_smoke.py
+++ b/tests/integration/optional_opencv_operation_provider_build_smoke.py
@@ -16,6 +16,54 @@ from cmake_build_smoke_support import remove_work_tree
 #: @brief Build-relative directory containing CMake-owned validation manifests.
 #: @note The directory is generated during configure and is never installed.
 CI_INVENTORY_RELATIVE_DIRECTORY = pathlib.Path("generated/ci_inventory")
+#: @brief Exact first record required by every registered-GTest TSV manifest.
+#: @note No comment, blank, or repeated-header record is legal after this line.
+REGISTERED_GTEST_TARGET_INVENTORY_HEADER = (
+    "# target\tconfigured executable"
+)
+#: @brief Legal local executable-target spelling shared with the CMake writer.
+#: @note Colons are excluded because root BUILDSYSTEM_TARGETS entries are local
+#:   targets rather than imported or alias names.
+REGISTERED_GTEST_TARGET_NAME_PATTERN = re.compile(r"[A-Za-z0-9_.+-]+")
+
+
+def contains_forbidden_ascii_control(
+    text: str, allowed_controls: str = ""
+) -> bool:
+    """@brief Detect ASCII controls that are not structural delimiters.
+
+    @param text Exact manifest text or field to inspect.
+    @param allowed_controls Control characters reserved by the current record
+      format, normally LF and TAB while validating the complete TSV.
+    @return True if text contains a disallowed C0 control or DEL; otherwise
+      False.
+    @throws None Character inspection is deterministic and in-memory.
+    @note NUL is included even though CMake strings cannot represent it, so an
+      externally modified or forged manifest still fails closed.
+    """
+
+    return any(
+        character not in allowed_controls
+        and (ord(character) < 32 or ord(character) == 127)
+        for character in text
+    )
+
+
+def is_portable_absolute_path(path_text: str) -> bool:
+    """@brief Recognize native absolute paths independent of the host OS.
+
+    @param path_text One control-free executable-path TSV field.
+    @return True for an absolute POSIX path, Windows drive-rooted path, or
+      Windows UNC path; otherwise False.
+    @throws None Pure path parsing performs no filesystem access.
+    @note Backslashes are valid Windows path data. The caller later creates a
+      host-native ``Path`` so real same-host manifests retain ``is_file``
+      behavior, while cross-platform safety fixtures remain parseable.
+    """
+
+    return pathlib.PurePosixPath(path_text).is_absolute() or (
+        pathlib.PureWindowsPath(path_text).is_absolute()
+    )
 
 
 def run(command: list[str], cwd: pathlib.Path) -> None:
@@ -107,17 +155,23 @@ def registered_gtest_target_files(
     @throws OSError If the generated inventory cannot be read.
     @throws UnicodeError If the generated inventory is not valid UTF-8.
     @throws RuntimeError If the configuration or inventory is missing,
-      malformed, empty, duplicated, or contains a relative executable path.
+      malformed, empty, duplicated, contains controls, lacks its exact unique
+      header, or contains an invalid target or relative executable path.
     @note CMake generates the TSV from its ``gtest_discover_tests`` registration
-      metadata and ``$<TARGET_FILE:...>`` expressions. This parser does not
-      infer registrations from source filenames or from CTest's observed
-      sentinel set.
+      metadata and ``$<TARGET_FILE:...>`` expressions. Each later line is
+      exactly one two-field data record; comments, repeated headers, and blank
+      lines are rejected. POSIX absolute paths and Windows drive/UNC paths are
+      accepted without rejecting ordinary spaces or Windows backslashes. This
+      parser does not infer registrations from source filenames or from
+      CTest's observed sentinel set.
     """
 
     if (
         not configuration
-        or pathlib.PurePath(configuration).name != configuration
+        or pathlib.PurePosixPath(configuration).name != configuration
+        or pathlib.PureWindowsPath(configuration).name != configuration
         or configuration in {".", ".."}
+        or contains_forbidden_ascii_control(configuration)
     ):
         raise RuntimeError(
             "invalid nested provider build configuration for GoogleTest "
@@ -134,30 +188,51 @@ def registered_gtest_target_files(
             f"{inventory_path}"
         )
 
+    with inventory_path.open(
+        "r", encoding="utf-8", newline=""
+    ) as inventory_file:
+        inventory_text = inventory_file.read()
+    if contains_forbidden_ascii_control(inventory_text, "\n\t"):
+        raise RuntimeError(
+            "configured GoogleTest target inventory contains a forbidden "
+            "ASCII control character"
+        )
+    lines = inventory_text.split("\n")
+    if lines and not lines[-1]:
+        lines.pop()
+    if not lines or lines[0] != REGISTERED_GTEST_TARGET_INVENTORY_HEADER:
+        raise RuntimeError(
+            "configured GoogleTest target inventory has a missing or "
+            "invalid header"
+        )
+
     targets: dict[str, pathlib.Path] = {}
-    for line in inventory_path.read_text(encoding="utf-8").splitlines():
-        if line.startswith("#"):
-            continue
+    for line_number, line in enumerate(lines[1:], start=2):
         if not line:
             raise RuntimeError(
                 "configured GoogleTest target inventory contains a blank entry"
+            )
+        if line.startswith("#"):
+            raise RuntimeError(
+                "configured GoogleTest target inventory contains a comment "
+                f"or repeated header at line {line_number}"
             )
         fields = line.split("\t")
         if len(fields) != 2:
             raise RuntimeError(
                 "configured GoogleTest target inventory contains a malformed "
-                f"entry: {line!r}"
+                f"entry at line {line_number}"
             )
         target_name, executable_text = fields
         executable = pathlib.Path(executable_text)
         if (
-            re.fullmatch(r"[A-Za-z0-9_.:+-]+", target_name) is None
+            REGISTERED_GTEST_TARGET_NAME_PATTERN.fullmatch(target_name) is None
             or target_name.endswith("_NOT_BUILT")
-            or not executable.is_absolute()
+            or not is_portable_absolute_path(executable_text)
         ):
             raise RuntimeError(
                 "configured GoogleTest target inventory contains an invalid "
-                f"entry: {line!r}"
+                f"entry at line {line_number}"
             )
         if target_name in targets:
             raise RuntimeError(

--- a/tests/integration/optional_opencv_operation_provider_build_smoke.py
+++ b/tests/integration/optional_opencv_operation_provider_build_smoke.py
@@ -7,9 +7,15 @@ import argparse
 import json
 import os
 import pathlib
+import re
 import subprocess
 
 from cmake_build_smoke_support import remove_work_tree
+
+
+#: @brief Build-relative directory containing CMake-owned validation manifests.
+#: @note The directory is generated during configure and is never installed.
+CI_INVENTORY_RELATIVE_DIRECTORY = pathlib.Path("generated/ci_inventory")
 
 
 def run(command: list[str], cwd: pathlib.Path) -> None:
@@ -86,6 +92,107 @@ def validate_provider_disabled_cache(values: dict[str, str]) -> None:
             "nested provider-disabled cache profile mismatch: "
             f"{mismatches}"
         )
+
+
+def registered_gtest_target_files(
+    build: pathlib.Path, configuration: str
+) -> dict[str, pathlib.Path]:
+    """@brief Read configured GoogleTest targets and executable locations.
+
+    @param build Configured nested provider-disabled build directory.
+    @param configuration Exact single- or multi-config name selected for the
+      nested build.
+    @return Mapping from every uniquely registered GoogleTest target to its
+      configuration-specific executable path.
+    @throws OSError If the generated inventory cannot be read.
+    @throws UnicodeError If the generated inventory is not valid UTF-8.
+    @throws RuntimeError If the configuration or inventory is missing,
+      malformed, empty, duplicated, or contains a relative executable path.
+    @note CMake generates the TSV from its ``gtest_discover_tests`` registration
+      metadata and ``$<TARGET_FILE:...>`` expressions. This parser does not
+      infer registrations from source filenames or from CTest's observed
+      sentinel set.
+    """
+
+    if (
+        not configuration
+        or pathlib.PurePath(configuration).name != configuration
+        or configuration in {".", ".."}
+    ):
+        raise RuntimeError(
+            "invalid nested provider build configuration for GoogleTest "
+            f"inventory: {configuration!r}"
+        )
+    inventory_path = (
+        build
+        / CI_INVENTORY_RELATIVE_DIRECTORY
+        / f"registered_gtest_targets-{configuration}.tsv"
+    )
+    if not inventory_path.is_file():
+        raise RuntimeError(
+            "configured GoogleTest target inventory is missing: "
+            f"{inventory_path}"
+        )
+
+    targets: dict[str, pathlib.Path] = {}
+    for line in inventory_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("#"):
+            continue
+        if not line:
+            raise RuntimeError(
+                "configured GoogleTest target inventory contains a blank entry"
+            )
+        fields = line.split("\t")
+        if len(fields) != 2:
+            raise RuntimeError(
+                "configured GoogleTest target inventory contains a malformed "
+                f"entry: {line!r}"
+            )
+        target_name, executable_text = fields
+        executable = pathlib.Path(executable_text)
+        if (
+            re.fullmatch(r"[A-Za-z0-9_.:+-]+", target_name) is None
+            or target_name.endswith("_NOT_BUILT")
+            or not executable.is_absolute()
+        ):
+            raise RuntimeError(
+                "configured GoogleTest target inventory contains an invalid "
+                f"entry: {line!r}"
+            )
+        if target_name in targets:
+            raise RuntimeError(
+                "configured GoogleTest target inventory contains a duplicate "
+                f"target: {target_name!r}"
+            )
+        targets[target_name] = executable
+    if not targets:
+        raise RuntimeError("configured GoogleTest target inventory is empty")
+    return targets
+
+
+def expected_registered_gtest_sentinels(
+    build: pathlib.Path, configuration: str
+) -> set[str]:
+    """@brief Derive exact registered-but-unbuilt CTest placeholders.
+
+    @param build Configured and selectively built provider-disabled tree.
+    @param configuration Exact configuration whose target paths were built.
+    @return Sentinel names for registered GoogleTest executables that are not
+      regular files after the focused build.
+    @throws OSError If the configured target inventory cannot be read.
+    @throws UnicodeError If the configured inventory is not valid UTF-8.
+    @throws RuntimeError If the configured target inventory is invalid.
+    @note Target-file existence observes the real build closure, including
+      targets built indirectly as dependencies. The returned names follow
+      CMake GoogleTest's exact ``${target}_NOT_BUILT`` convention.
+    """
+
+    targets = registered_gtest_target_files(build, configuration)
+    return {
+        f"{target_name}_NOT_BUILT"
+        for target_name, executable in targets.items()
+        if not executable.is_file()
+    }
 
 
 def parse_ctest_inventory(
@@ -188,14 +295,19 @@ def query_ctest_inventory(
 
 def validate_provider_disabled_inventory(
     inventory: dict[str, dict[str, object]],
+    expected_sentinels: set[str],
 ) -> None:
     """@brief Require the runnable provider-disabled CTest surface.
 
     @param inventory Unique registered tests and properties from the nested
       build.
-    @return None when only the intended focused tests and install smoke exist.
-    @throws RuntimeError If a focused test is missing, a broad-suite test
-      remains registered, or a required concurrency property drifts.
+    @param expected_sentinels Exact registered-but-unbuilt names derived from
+      CMake's target inventory and the completed focused build closure.
+    @return None when only the intended focused tests, install smoke, and
+      CMake-derived registered-only sentinels exist.
+    @throws RuntimeError If a focused test is missing, a sentinel is malformed
+      or has properties, a broad-suite test remains registered, or a required
+      concurrency property drifts.
     @note `test_kernel_contracts` remains a buildable focused target for the
       separate injected-codec smoke but is deliberately not broadly discovered
       in this provider-disabled CTest inventory.
@@ -225,18 +337,42 @@ def validate_provider_disabled_inventory(
             "ShutdownAndGraphPublicationShareOneProductionAdmissionBoundary"
         ),
     }
+    malformed_sentinels = sorted(
+        name
+        for name in expected_sentinels
+        if re.fullmatch(r"[A-Za-z0-9_.:+-]+_NOT_BUILT", name) is None
+    )
+    if malformed_sentinels:
+        raise RuntimeError(
+            "provider-disabled expected sentinel inventory is malformed: "
+            f"{malformed_sentinels}"
+        )
     expected = {
         "DependencyDisabledInstallSmoke",
         (
             "OptionalOpenCvOperationProvider."
             "ReplacementExecutesAndRestores"
         ),
-    } | disk_cache_tests | lifecycle_tests
+    } | disk_cache_tests | lifecycle_tests | expected_sentinels
     names = set(inventory)
     if names != expected:
         raise RuntimeError(
             "provider-disabled CTest inventory mismatch: "
             f"expected {sorted(expected)}, got {sorted(names)}"
+        )
+
+    sentinel_property_mismatches = {
+        name: {
+            "LABELS": inventory[name].get("LABELS"),
+            "TIMEOUT": inventory[name].get("TIMEOUT"),
+        }
+        for name in expected_sentinels
+        if "LABELS" in inventory[name] or "TIMEOUT" in inventory[name]
+    }
+    if sentinel_property_mismatches:
+        raise RuntimeError(
+            "provider-disabled registered-only CTest property mismatch: "
+            f"{sentinel_property_mismatches}"
         )
 
     expected_properties = {
@@ -397,7 +533,10 @@ def main() -> int:
     inventory = query_ctest_inventory(
         args.ctest_executable, work, configuration, repo
     )
-    validate_provider_disabled_inventory(inventory)
+    validate_provider_disabled_inventory(
+        inventory,
+        expected_registered_gtest_sentinels(work, configuration),
+    )
     run(
         [
             args.ctest_executable,

--- a/tests/integration/optional_opencv_operation_provider_build_smoke_test.py
+++ b/tests/integration/optional_opencv_operation_provider_build_smoke_test.py
@@ -76,11 +76,14 @@ def ctest_json_test(
     return {"name": name, "properties": properties}
 
 
-def provider_disabled_ctest_payload() -> str:
+def provider_disabled_ctest_payload(
+    sentinels: tuple[str, ...] = (),
+) -> str:
     """@brief Construct the valid provider-disabled JSON-v1 inventory.
 
+    @param sentinels Registered-but-unbuilt target names with no properties.
     @return JSON payload containing two profile entries, three disk cases, and
-      two production lifecycle cases.
+      two production lifecycle cases plus the requested sentinels.
     @throws Nothing; every serialized value is deterministic and JSON-safe.
     @note Disk cases receive a 20-second timeout; lifecycle cases receive a
       60-second timeout. Both groups use the exact `kernel-concurrency` label.
@@ -91,6 +94,7 @@ def provider_disabled_ctest_payload() -> str:
         OPTIONAL_PROVIDER_CTEST_NAME,
         *DISK_CACHE_CTEST_NAMES,
         *KERNEL_LIFECYCLE_CTEST_NAMES,
+        *sentinels,
     }
     return json.dumps(
         {
@@ -811,7 +815,89 @@ class ProviderDisabledProfileTest(unittest.TestCase):
         )
 
         self.assertEqual(set(inventory), expected)
-        subject.validate_provider_disabled_inventory(inventory)
+        subject.validate_provider_disabled_inventory(inventory, set())
+
+    def test_derives_registered_only_sentinels_from_target_manifest(
+        self,
+    ) -> None:
+        """@brief Derive placeholders from registered target-file existence.
+
+        @return None after one built target is excluded and two arbitrary
+          unbuilt registered targets become exact sentinels.
+        @throws OSError If the synthetic manifest or executable cannot be
+          created.
+        @throws AssertionError If parsing loses registrations, depends on a
+          known future target name, or accepts malformed metadata.
+        @note Every path belongs to a disposable synthetic build. The arbitrary
+          future target proves derivation is registration-driven rather than a
+          source-file or count special case.
+        """
+
+        with synthetic_temporary_directory(
+            prefix="photospider-provider-gtest-inventory-"
+        ) as temporary:
+            build = pathlib.Path(temporary) / "build"
+            inventory_dir = build / subject.CI_INVENTORY_RELATIVE_DIRECTORY
+            inventory_dir.mkdir(parents=True)
+            executable_dir = build / "tests"
+            executable_dir.mkdir()
+            built_target = executable_dir / "test_built"
+            built_target.write_text("synthetic executable", encoding="utf-8")
+            unbuilt_target = executable_dir / "test_unbuilt"
+            future_target = executable_dir / "test_arbitrary_future"
+            manifest = inventory_dir / (
+                "registered_gtest_targets-RelWithDebInfo.tsv"
+            )
+            manifest.write_text(
+                "# target\tconfigured executable\n"
+                f"test_built\t{built_target}\n"
+                f"test_unbuilt\t{unbuilt_target}\n"
+                f"test_arbitrary_future\t{future_target}\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                subject.registered_gtest_target_files(
+                    build, "RelWithDebInfo"
+                ),
+                {
+                    "test_arbitrary_future": future_target,
+                    "test_built": built_target,
+                    "test_unbuilt": unbuilt_target,
+                },
+            )
+            sentinels = subject.expected_registered_gtest_sentinels(
+                build, "RelWithDebInfo"
+            )
+            self.assertEqual(
+                sentinels,
+                {
+                    "test_arbitrary_future_NOT_BUILT",
+                    "test_unbuilt_NOT_BUILT",
+                },
+            )
+            inventory = subject.parse_ctest_inventory(
+                provider_disabled_ctest_payload(tuple(sorted(sentinels)))
+            )
+            subject.validate_provider_disabled_inventory(
+                inventory, sentinels
+            )
+
+            malformed_entries = (
+                "test_relative\trelative/test_relative\n",
+                f"test_built\t{built_target}\ntest_built\t{built_target}\n",
+                f"test_bad_NOT_BUILT\t{unbuilt_target}\n",
+                "blank-target\n",
+            )
+            for entry in malformed_entries:
+                with self.subTest(entry=entry):
+                    manifest.write_text(entry, encoding="utf-8")
+                    with self.assertRaisesRegex(
+                        RuntimeError, "inventory contains"
+                    ):
+                        subject.registered_gtest_target_files(
+                            build, "RelWithDebInfo"
+                        )
 
     def test_rejects_malformed_broad_or_drifted_ctest_inventory(self) -> None:
         """@brief Reject malformed, broad, missing, or drifted inventories.
@@ -845,7 +931,7 @@ class ProviderDisabledProfileTest(unittest.TestCase):
         }
         with self.assertRaisesRegex(RuntimeError, "inventory mismatch"):
             subject.validate_provider_disabled_inventory(
-                old_full_only_inventory
+                old_full_only_inventory, set()
             )
 
         valid_inventory = subject.parse_ctest_inventory(
@@ -860,7 +946,9 @@ class ProviderDisabledProfileTest(unittest.TestCase):
             "build-smoke",
         ]
         with self.assertRaisesRegex(RuntimeError, "property mismatch"):
-            subject.validate_provider_disabled_inventory(drifted_inventory)
+            subject.validate_provider_disabled_inventory(
+                drifted_inventory, set()
+            )
 
         drifted_lifecycle_inventory = {
             name: dict(properties)
@@ -871,7 +959,7 @@ class ProviderDisabledProfileTest(unittest.TestCase):
         ] = 20
         with self.assertRaisesRegex(RuntimeError, "property mismatch"):
             subject.validate_provider_disabled_inventory(
-                drifted_lifecycle_inventory
+                drifted_lifecycle_inventory, set()
             )
 
         broad_inventory = {
@@ -880,7 +968,9 @@ class ProviderDisabledProfileTest(unittest.TestCase):
         }
         broad_inventory["test_scheduler_NOT_BUILT"] = {}
         with self.assertRaisesRegex(RuntimeError, "inventory mismatch"):
-            subject.validate_provider_disabled_inventory(broad_inventory)
+            subject.validate_provider_disabled_inventory(
+                broad_inventory, set()
+            )
 
 
 if __name__ == "__main__":

--- a/tests/integration/optional_opencv_operation_provider_build_smoke_test.py
+++ b/tests/integration/optional_opencv_operation_provider_build_smoke_test.py
@@ -7,6 +7,7 @@ import json
 import os
 import pathlib
 import stat
+import subprocess
 import tempfile
 import unittest
 from typing import Optional
@@ -15,6 +16,36 @@ from unittest import mock
 import cmake_build_smoke_support as build_support
 import image_artifact_codec_dependency_disabled_smoke as image_consumer
 import optional_opencv_operation_provider_build_smoke as subject
+
+
+#: @brief Resolved repository root used to load the production CMake writer.
+#: @note The path is immutable and never passed to destructive helpers.
+REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[2]
+#: @brief Exact CMake module used by the root producer configuration.
+#: @note The safety fixture includes this module directly, avoiding a duplicate
+#:   test-only generator implementation.
+CI_INVENTORY_CMAKE_MODULE_PATH = (
+    REPOSITORY_ROOT / "cmake" / "PhotospiderCiInventory.cmake"
+)
+#: @brief CMake launcher for the production generator fixture.
+#: @note CTest supplies CMAKE_COMMAND through the environment; direct unittest
+#:   execution resolves the conventional cmake command through PATH.
+CMAKE_EXECUTABLE = os.environ.get("PHOTOSPIDER_CMAKE_EXECUTABLE", "cmake")
+
+
+def write_exact_text(path: pathlib.Path, text: str) -> None:
+    """@brief Write one UTF-8 fixture without host newline conversion.
+
+    @param path Existing-parent test-owned destination.
+    @param text Exact CMake or manifest text to serialize.
+    @return None after the file is closed successfully.
+    @throws OSError If the fixture cannot be opened or written.
+    @note Explicit ``newline=''`` preserves CR/LF injection cases on Python 3.9
+      and later and keeps CMake fixture inputs byte-stable across host systems.
+    """
+
+    with path.open("w", encoding="utf-8", newline="") as output_file:
+        output_file.write(text)
 
 
 #: @brief Stable disk-cache concurrency cases required in focused inventories.
@@ -762,10 +793,15 @@ class ConfigurationLayoutTest(unittest.TestCase):
 class ProviderDisabledProfileTest(unittest.TestCase):
     """@brief Verifies cache and CTest inventory profile contracts.
 
+    @throws OSError If a synthetic manifest or compiler-free CMake generator
+      fixture cannot be created or started.
+    @throws subprocess.CalledProcessError If the valid production-generator
+      fixture fails configuration.
     @throws AssertionError When the validator accepts a mismatched capability
       profile or provider-dependent broad-suite inventory.
-    @note Tests use only synthetic dictionaries and JSON; no CMake process or
-      real build tree is accessed.
+    @note Tests use disposable dictionaries, JSON, manifests, and one
+      ``project(... NONE)`` generator fixture. No compiler, product build,
+      install, or generated executable is started.
     """
 
     def test_accepts_exact_cache_and_rejects_provider_mismatch(self) -> None:
@@ -848,12 +884,12 @@ class ProviderDisabledProfileTest(unittest.TestCase):
             manifest = inventory_dir / (
                 "registered_gtest_targets-RelWithDebInfo.tsv"
             )
-            manifest.write_text(
+            write_exact_text(
+                manifest,
                 "# target\tconfigured executable\n"
                 f"test_built\t{built_target}\n"
                 f"test_unbuilt\t{unbuilt_target}\n"
                 f"test_arbitrary_future\t{future_target}\n",
-                encoding="utf-8",
             )
 
             self.assertEqual(
@@ -883,21 +919,246 @@ class ProviderDisabledProfileTest(unittest.TestCase):
                 inventory, sentinels
             )
 
-            malformed_entries = (
-                "test_relative\trelative/test_relative\n",
-                f"test_built\t{built_target}\ntest_built\t{built_target}\n",
-                f"test_bad_NOT_BUILT\t{unbuilt_target}\n",
-                "blank-target\n",
+            malformed_payloads = {
+                "missing-header": f"test_built\t{built_target}\n",
+                "wrong-header": (
+                    "# wrong\tconfigured executable\n"
+                    f"test_built\t{built_target}\n"
+                ),
+                "repeated-header": (
+                    f"{subject.REGISTERED_GTEST_TARGET_INVENTORY_HEADER}\n"
+                    f"test_built\t{built_target}\n"
+                    f"{subject.REGISTERED_GTEST_TARGET_INVENTORY_HEADER}\n"
+                ),
+                "later-comment": (
+                    f"{subject.REGISTERED_GTEST_TARGET_INVENTORY_HEADER}\n"
+                    f"test_built\t{built_target}\n"
+                    "# injected comment\n"
+                ),
+                "blank-line": (
+                    f"{subject.REGISTERED_GTEST_TARGET_INVENTORY_HEADER}\n"
+                    f"test_built\t{built_target}\n\n"
+                ),
+                "extra-field": (
+                    f"{subject.REGISTERED_GTEST_TARGET_INVENTORY_HEADER}\n"
+                    f"test_built\t{built_target}\textra\n"
+                ),
+                "relative-path": (
+                    f"{subject.REGISTERED_GTEST_TARGET_INVENTORY_HEADER}\n"
+                    "test_relative\trelative/test_relative\n"
+                ),
+                "duplicate-target": (
+                    f"{subject.REGISTERED_GTEST_TARGET_INVENTORY_HEADER}\n"
+                    f"test_built\t{built_target}\n"
+                    f"test_built\t{built_target}\n"
+                ),
+                "sentinel-target": (
+                    f"{subject.REGISTERED_GTEST_TARGET_INVENTORY_HEADER}\n"
+                    f"test_bad_NOT_BUILT\t{unbuilt_target}\n"
+                ),
+                "alias-target": (
+                    f"{subject.REGISTERED_GTEST_TARGET_INVENTORY_HEADER}\n"
+                    f"test::alias\t{unbuilt_target}\n"
+                ),
+                "single-field": (
+                    f"{subject.REGISTERED_GTEST_TARGET_INVENTORY_HEADER}\n"
+                    "blank-target\n"
+                ),
+                "delete-in-path": (
+                    f"{subject.REGISTERED_GTEST_TARGET_INVENTORY_HEADER}\n"
+                    "test_delete\t/absolute/del\x7fpath\n"
+                ),
+            }
+            malformed_payloads.update(
+                {
+                    f"c0-in-path-{control_code}": (
+                        f"{subject.REGISTERED_GTEST_TARGET_INVENTORY_HEADER}\n"
+                        "test_control\t/absolute/control"
+                        f"{chr(control_code)}path\n"
+                    )
+                    for control_code in range(32)
+                }
             )
-            for entry in malformed_entries:
-                with self.subTest(entry=entry):
-                    manifest.write_text(entry, encoding="utf-8")
+            for case_name, payload in malformed_payloads.items():
+                with self.subTest(case=case_name):
+                    write_exact_text(manifest, payload)
                     with self.assertRaisesRegex(
-                        RuntimeError, "inventory contains"
+                        RuntimeError, "inventory"
                     ):
                         subject.registered_gtest_target_files(
                             build, "RelWithDebInfo"
                         )
+
+    def test_accepts_portable_absolute_paths_per_configuration(self) -> None:
+        """@brief Accept safe POSIX and Windows target-file spellings.
+
+        @return None after independent Debug and RelWithDebInfo manifests accept
+          POSIX paths with spaces, Windows drive paths with either separator,
+          and a Windows UNC path.
+        @throws OSError If a synthetic configuration manifest cannot be written.
+        @throws AssertionError If a safe path is rejected, configurations bleed
+          together, or a relative Windows path is classified as absolute.
+        @note Cross-platform parsing is lexical. Only same-host paths reach the
+          later ``is_file`` observation in the real smoke.
+        """
+
+        self.assertFalse(subject.is_portable_absolute_path("C:relative.exe"))
+        portable_paths = {
+            "test_posix_space": "/absolute/path with space/test executable",
+            "test_windows_backslash": (
+                r"C:\Program Files\Photospider\test_provider.exe"
+            ),
+            "test_windows_forward": (
+                "D:/build with space/Photospider/test_provider.exe"
+            ),
+            "test_windows_unc": (
+                r"\\server\build share\Photospider\test_provider.exe"
+            ),
+        }
+        with synthetic_temporary_directory(
+            prefix="photospider-provider-portable-paths-"
+        ) as temporary:
+            build = pathlib.Path(temporary) / "build"
+            inventory_dir = build / subject.CI_INVENTORY_RELATIVE_DIRECTORY
+            inventory_dir.mkdir(parents=True)
+            for configuration in ("Debug", "RelWithDebInfo"):
+                manifest = inventory_dir / (
+                    f"registered_gtest_targets-{configuration}.tsv"
+                )
+                write_exact_text(
+                    manifest,
+                    f"{subject.REGISTERED_GTEST_TARGET_INVENTORY_HEADER}\n"
+                    + "".join(
+                        f"{target_name}\t{path_text}\n"
+                        for target_name, path_text in portable_paths.items()
+                    ),
+                )
+                parsed = subject.registered_gtest_target_files(
+                    build, configuration
+                )
+                self.assertEqual(set(parsed), set(portable_paths))
+                for target_name, path_text in portable_paths.items():
+                    with self.subTest(
+                        configuration=configuration,
+                        target=target_name,
+                    ):
+                        self.assertTrue(
+                            subject.is_portable_absolute_path(path_text)
+                        )
+                        self.assertEqual(
+                            parsed[target_name], pathlib.Path(path_text)
+                        )
+
+    def test_cmake_generator_emits_strict_configuration_manifest(
+        self,
+    ) -> None:
+        """@brief Round-trip the production CMake generator into the parser.
+
+        @return None after the real helper preserves a legal local target name,
+          ordinary path spaces, and the RelWithDebInfo ``$<CONFIG>`` output.
+        @throws OSError If the synthetic CMake project cannot be written or the
+          configured launcher cannot start.
+        @throws subprocess.CalledProcessError If the valid fixture configure or
+          generation step fails.
+        @throws AssertionError If generated TSV content fails the production
+          parser or an illegal CMake target name reaches generation.
+        @note The fixture uses an imported executable and ``project(... NONE)``;
+          it runs CMake generation without a compiler, build, or executable.
+          Both build-type variables are set so single- and multi-config
+          generators select the same isolated configuration.
+        """
+
+        with synthetic_temporary_directory(
+            prefix="photospider-provider-cmake-inventory-"
+        ) as temporary:
+            sandbox = pathlib.Path(temporary)
+            source = sandbox / "source"
+            build = sandbox / "build"
+            source.mkdir()
+            configured_executable = (
+                sandbox / "bin with space" / "test.generated+target"
+            )
+            configured_executable.parent.mkdir()
+            write_exact_text(configured_executable, "synthetic executable")
+            write_exact_text(
+                source / "CMakeLists.txt",
+                "cmake_minimum_required(VERSION 3.16)\n"
+                "project(PhotospiderCiInventoryFixture NONE)\n"
+                f'include("{CI_INVENTORY_CMAKE_MODULE_PATH.as_posix()}")\n'
+                "add_executable(test.generated+target IMPORTED GLOBAL)\n"
+                "set_target_properties(test.generated+target PROPERTIES\n"
+                f'  IMPORTED_LOCATION "{configured_executable.as_posix()}")\n'
+                "set(PHOTOSPIDER_TEST_GTEST_TARGETS "
+                "test.generated+target)\n"
+                "photospider_generate_registered_gtest_target_inventory(\n"
+                '  "${CMAKE_BINARY_DIR}/generated/ci_inventory/'
+                'registered_gtest_targets-$<CONFIG>.tsv"\n'
+                "  PHOTOSPIDER_TEST_GTEST_TARGETS)\n",
+            )
+            subprocess.run(
+                [
+                    CMAKE_EXECUTABLE,
+                    "-S",
+                    str(source),
+                    "-B",
+                    str(build),
+                    "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                    "-DCMAKE_CONFIGURATION_TYPES=RelWithDebInfo",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(
+                subject.registered_gtest_target_files(
+                    build, "RelWithDebInfo"
+                ),
+                {"test.generated+target": configured_executable},
+            )
+
+            rejected_script = sandbox / "reject_target_name.cmake"
+            write_exact_text(
+                rejected_script,
+                "cmake_minimum_required(VERSION 3.16)\n"
+                f'include("{CI_INVENTORY_CMAKE_MODULE_PATH.as_posix()}")\n'
+                "set(PHOTOSPIDER_TEST_GTEST_TARGETS "
+                '"${PHOTOSPIDER_TEST_TARGET_NAME}")\n'
+                "photospider_generate_registered_gtest_target_inventory(\n"
+                f'  "{(sandbox / "rejected.tsv").as_posix()}"\n'
+                "  PHOTOSPIDER_TEST_GTEST_TARGETS)\n",
+            )
+            for invalid_target_name in (
+                "test::alias",
+                "test target",
+                "test_target_NOT_BUILT",
+                "test\ttarget",
+                "test\ntarget",
+                "test\x7ftarget",
+            ):
+                with self.subTest(target=repr(invalid_target_name)):
+                    result = subprocess.run(
+                        [
+                            CMAKE_EXECUTABLE,
+                            (
+                                "-DPHOTOSPIDER_TEST_TARGET_NAME="
+                                f"{invalid_target_name}"
+                            ),
+                            "-P",
+                            str(rejected_script),
+                        ],
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertRegex(
+                        result.stderr,
+                        (
+                            r"(?:forbidden ASCII control code|"
+                            r"invalid CMake target name)"
+                        ),
+                    )
+                    self.assertNotIn(invalid_target_name, result.stderr)
 
     def test_rejects_malformed_broad_or_drifted_ctest_inventory(self) -> None:
         """@brief Reject malformed, broad, missing, or drifted inventories.

--- a/tests/integration/static_product_consumer_smoke.py
+++ b/tests/integration/static_product_consumer_smoke.py
@@ -653,10 +653,14 @@ def public_header_includes(build: Path) -> list[str]:
     @throws OSError If the configured inventory cannot be read.
     @throws UnicodeError If the configured inventory is not valid UTF-8.
     @throws RuntimeError If the inventory is missing, empty, duplicated, or
-      contains a noncanonical/non-header path outside ``include/photospider``.
+      contains a control byte, backslash, or noncanonical/non-header POSIX path
+      outside ``include/photospider``.
     @note CMake serializes the same explicit relative-path list used by its
-      install rules. The smoke never scans the source tree or maintains a
-      second expected header count.
+      install rules after applying the same control/backslash policy. NUL is
+      impossible in a CMake string but remains rejected here for forged or
+      externally modified manifests. Ordinary spaces remain valid path data.
+      The smoke never scans the source tree or maintains a second expected
+      header count.
     """
 
     inventory_path = build / PUBLIC_HEADER_INVENTORY_RELATIVE_PATH
@@ -665,7 +669,22 @@ def public_header_includes(build: Path) -> list[str]:
             "configured public-header inventory is missing: "
             f"{inventory_path}"
         )
-    raw_headers = inventory_path.read_text(encoding="utf-8").splitlines()
+    with inventory_path.open(
+        "r", encoding="utf-8", newline=""
+    ) as inventory_file:
+        inventory_text = inventory_file.read()
+    if any(
+        character != "\n"
+        and (ord(character) < 32 or ord(character) == 127)
+        for character in inventory_text
+    ):
+        raise RuntimeError(
+            "configured public-header inventory contains a forbidden "
+            "ASCII control character"
+        )
+    raw_headers = inventory_text.split("\n")
+    if raw_headers and not raw_headers[-1]:
+        raw_headers.pop()
     if not raw_headers or any(not header for header in raw_headers):
         raise RuntimeError(
             "configured public-header inventory is empty or contains a "
@@ -673,7 +692,12 @@ def public_header_includes(build: Path) -> list[str]:
         )
 
     headers: set[str] = set()
-    for raw_header in raw_headers:
+    for line_number, raw_header in enumerate(raw_headers, start=1):
+        if "\\" in raw_header:
+            raise RuntimeError(
+                "configured public-header inventory contains a forbidden "
+                f"backslash at line {line_number}"
+            )
         header = PurePosixPath(raw_header)
         if (
             header.as_posix() != raw_header

--- a/tests/integration/static_product_consumer_smoke.py
+++ b/tests/integration/static_product_consumer_smoke.py
@@ -14,7 +14,7 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from textwrap import dedent
 from typing import Any, Callable
 
@@ -116,6 +116,13 @@ EXPECTED_IPC_DIRECT_INCLUDES = {
         "photospider/host/compute_request.hpp",
     ),
 }
+
+#: @brief Configured CMake allowlist consumed by the package smoke.
+#: @note The path is relative to the producer build tree and remains a
+#:   generated validation input rather than an installed package artifact.
+PUBLIC_HEADER_INVENTORY_RELATIVE_PATH = Path(
+    "generated/ci_inventory/installable_public_headers.txt"
+)
 FORBIDDEN_IPC_DECLARATION_PATTERNS = {
     "backend implementation type": (
         r"\b(?:Kernel|GraphModel|InteractionService|ComputeService|"
@@ -636,23 +643,61 @@ def configure_fresh_producer(
     return run_command(command, repo)
 
 
-def public_header_includes(repo: Path) -> list[str]:
-    """@brief Generate includes for every installable public header.
+def public_header_includes(build: Path) -> list[str]:
+    """@brief Load exact consumer includes from CMake's install allowlist.
 
-    @param repo Repository root containing ``include/photospider``.
-    @return Sorted ``#include`` directives relative to ``include``.
-    @throws OSError If the public header tree cannot be traversed.
-    @note The function is read-only and filters to C/C++ header suffixes used by
-      the install rule.
+    @param build Configured producer build tree containing the generated
+      public-header inventory.
+    @return Sorted ``#include`` directives relative to the installed include
+      root.
+    @throws OSError If the configured inventory cannot be read.
+    @throws UnicodeError If the configured inventory is not valid UTF-8.
+    @throws RuntimeError If the inventory is missing, empty, duplicated, or
+      contains a noncanonical/non-header path outside ``include/photospider``.
+    @note CMake serializes the same explicit relative-path list used by its
+      install rules. The smoke never scans the source tree or maintains a
+      second expected header count.
     """
 
-    public_root = repo / "include" / "photospider"
-    headers = sorted(
-        path.relative_to(repo / "include").as_posix()
-        for path in public_root.rglob("*")
-        if path.is_file() and path.suffix in {".h", ".hpp", ".hh", ".hxx"}
-    )
-    return [f"#include <{header}>" for header in headers]
+    inventory_path = build / PUBLIC_HEADER_INVENTORY_RELATIVE_PATH
+    if not inventory_path.is_file():
+        raise RuntimeError(
+            "configured public-header inventory is missing: "
+            f"{inventory_path}"
+        )
+    raw_headers = inventory_path.read_text(encoding="utf-8").splitlines()
+    if not raw_headers or any(not header for header in raw_headers):
+        raise RuntimeError(
+            "configured public-header inventory is empty or contains a "
+            "blank entry"
+        )
+
+    headers: set[str] = set()
+    for raw_header in raw_headers:
+        header = PurePosixPath(raw_header)
+        if (
+            header.as_posix() != raw_header
+            or header.is_absolute()
+            or header.parts[:2] != ("include", "photospider")
+            or len(header.parts) < 3
+            or any(part in {"", ".", ".."} for part in header.parts)
+            or header.suffix not in {".h", ".hpp", ".hh", ".hxx"}
+        ):
+            raise RuntimeError(
+                "configured public-header inventory contains an invalid "
+                f"entry: {raw_header!r}"
+            )
+        if raw_header in headers:
+            raise RuntimeError(
+                "configured public-header inventory contains a duplicate "
+                f"entry: {raw_header!r}"
+            )
+        headers.add(raw_header)
+
+    return [
+        f"#include <{header.removeprefix('include/')}>"
+        for header in sorted(headers)
+    ]
 
 
 def ipc_consumer_source() -> str:
@@ -960,7 +1005,10 @@ def validate_complete_surface_inventory(source: str) -> dict[str, list[str]]:
 
 
 def write_consumer_projects(
-    repo: Path, embedded_source_dir: Path, ipc_source_dir: Path
+    repo: Path,
+    build: Path,
+    embedded_source_dir: Path,
+    ipc_source_dir: Path,
 ) -> tuple[list[str], dict[str, list[str]]]:
     """@brief Create independent embedded and IPC installed consumers.
 
@@ -971,7 +1019,9 @@ def write_consumer_projects(
     ``ipc_client`` component and links only its exported target. Each project
     generates its own target manifest for single- and multi-config generators.
 
-    @param repo Repository root used only to inventory public headers.
+    @param repo Repository root used by generated behavior sources.
+    @param build Configured producer build tree containing CMake's exact
+      installable-public-header inventory.
     @param embedded_source_dir Transient embedded consumer source directory.
     @param ipc_source_dir Transient IPC-only consumer source directory.
     @return Embedded include directives and verified IPC call inventories.
@@ -986,7 +1036,7 @@ def write_consumer_projects(
 
     embedded_source_dir.mkdir(parents=True, exist_ok=True)
     ipc_source_dir.mkdir(parents=True, exist_ok=True)
-    include_lines = public_header_includes(repo)
+    include_lines = public_header_includes(build)
     (embedded_source_dir / "CMakeLists.txt").write_text(
         "\n".join(
             [
@@ -2987,10 +3037,9 @@ def evaluate_behavior(observations: dict[str, Any]) -> bool:
         and install["targets_exists"],
         "only include/photospider headers are installed": install["unexpected_headers"]
         == [],
-        "installed public header inventory is exactly 21 files": len(install["headers"])
-        == 21,
-        "consumer compiles every installed public header": compiled_headers
-        == install["headers"],
+        "installed public headers match the configured CMake allowlist": (
+            install["headers"] == compiled_headers
+        ),
         "exported namespace target exists": install["export_mentions_namespace_target"],
         "exported IPC namespace target exists": install[
             "export_mentions_ipc_namespace_target"
@@ -3230,23 +3279,6 @@ def main() -> int:
     required_opencv_missing_build = work / "required-opencv-missing-build"
     unknown_component_src = work / "unknown-component-src"
     unknown_component_build = work / "unknown-component-build"
-    compiled_public_headers, surface_inventory = write_consumer_projects(
-        repo, embedded_consumer_src, ipc_consumer_src
-    )
-    unknown_component_src.mkdir(parents=True)
-    (unknown_component_src / "CMakeLists.txt").write_text(
-        "\n".join(
-            [
-                "cmake_minimum_required(VERSION 3.16)",
-                "project(photospider_unknown_component LANGUAGES CXX)",
-                "find_package(Photospider CONFIG REQUIRED",
-                "    COMPONENTS unknown_component)",
-                "",
-            ]
-        ),
-        encoding="utf-8",
-    )
-
     producer_configure_code: int | None = None
     if args.configure_fresh_producer:
         producer_configure_code = configure_fresh_producer(
@@ -3262,6 +3294,23 @@ def main() -> int:
             "fresh producer configure not requested; existing build tree used",
             flush=True,
         )
+
+    compiled_public_headers, surface_inventory = write_consumer_projects(
+        repo, build, embedded_consumer_src, ipc_consumer_src
+    )
+    unknown_component_src.mkdir(parents=True)
+    (unknown_component_src / "CMakeLists.txt").write_text(
+        "\n".join(
+            [
+                "cmake_minimum_required(VERSION 3.16)",
+                "project(photospider_unknown_component LANGUAGES CXX)",
+                "find_package(Photospider CONFIG REQUIRED",
+                "    COMPONENTS unknown_component)",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
     opencv_config_dir_value = cmake_cache_value(build, "OpenCV_DIR")
     if not opencv_config_dir_value or opencv_config_dir_value.endswith("-NOTFOUND"):


### PR DESCRIPTION
## Summary

- Generate the installable public-header inventory from the authoritative CMake allowlist and compare the installed package as an exact set.
- Generate the active GoogleTest target/executable inventory from CMake registration metadata and derive exact `_NOT_BUILT` sentinels from the completed focused build closure.
- Add fail-closed parser regressions and maintain the English validation docs plus Chinese mirrors.

This unblocks the CI inventory validation needed by Issue #90 without changing runtime behavior.

## Validation

- Repository healthcheck: PASS (18 change-classification, 15 build-smoke inventory, 9 runtime capability, 32 CI routing cases).
- Native clean configure: PASS.
- Native full build: PASS.
- Complete CTest with JUnit: 851 tests, 0 failures, 1 skipped; JUnit SHA-256 `513e9c007d3d8040e9e762db0d208dc2d183a58f00c654b8fcdfd7138418a05f`.
- Issue #90 baseline `a404877`: both original labelled smokes PASS; 30 configured headers match exactly, and the two derived sentinels are `test_compute_io_executor_NOT_BUILT` and `test_packed_fp4_dense_tensor_NOT_BUILT`.

## Risk

Low. The change affects CI/build-smoke inventory derivation and documentation only. Missing, extra, malformed, duplicated, or unexpectedly attributed entries continue to fail closed.