### PR TITLE
fix(ci): 使用 CMake 原生可执行文件名

### DIFF
--- a/docs/development/Testing-and-Validation.md
+++ b/docs/development/Testing-and-Validation.md
@@ -203,26 +203,42 @@ configuration, and complete capability profile are validated.
 
 The generated clean consumer project maintains one ordered CMake executable
 target list. That same list creates the targets, writes a configure-time exact
-target declaration, and supplies a configuration-specific two-field
-`target<TAB>$<TARGET_FILE:target>` manifest through `file(GENERATE)`. The current
-profile declares only `dependency_disabled_consumer`; adding another maintained
-consumer extends that CMake list and its source without adding a Python target
-name or discovery branch. The reader requires both manifests to be nonempty,
-unique, and identical in sequence. It rejects malformed fields, blank/comment
-records, invalid UTF-8, non-structural ASCII C0 controls or DEL, noncanonical
-target names, and missing, unexpected, duplicated, or reordered targets.
-Every resolved executable must use canonical native spelling, stay at the
-consumer build root or its selected configuration directory, match the target
-basename, avoid symlinks, and be an executable regular file. Collection, set,
-and path validation completes for the whole inventory before any consumer
-starts; valid consumers then run in declaration order and a runtime failure
+target declaration, and supplies a configuration-specific three-field
+`target<TAB>$<TARGET_FILE_NAME:target><TAB>$<TARGET_FILE:target>` manifest
+through `file(GENERATE)`. The current profile declares only
+`dependency_disabled_consumer`; adding another maintained consumer extends that
+CMake list and its source without adding a Python target name or discovery
+branch. CMake 3.16's target generator expressions are the native spelling
+authority because they describe the selected generator, target platform, and
+configuration. Python's `os.name` and `sys.platform` describe the interpreter
+host instead, so they must not infer the executable suffix. In particular, a
+POSIX Python running under Cygwin or MSYS2 may legitimately receive a CMake
+target filename ending in `.exe`.
+
+The reader requires both manifests to be nonempty, unique, and identical in
+target sequence. It rejects malformed field counts, empty fields,
+blank/comment records, invalid UTF-8, non-structural ASCII C0 controls or DEL,
+noncanonical target names, and missing, unexpected, duplicated, or reordered
+targets. A configured filename must contain no POSIX or Windows separator, may
+not be `.` or `..`, must be unique, and must equal either the exact target name
+or that name plus `.exe`. Those are the only native spellings available because
+the generated consumer does not customize `OUTPUT_NAME`, prefix, suffix, or a
+configuration postfix. This target-to-filename binding prevents a forged new
+field from selecting an arbitrary build-local executable. The full target path
+must use canonical native spelling, remain unique, stay at the consumer build
+root or its selected configuration directory, have a basename exactly equal to
+the CMake-declared filename, avoid symlinks, and identify an executable regular
+file. Both manifests are accepted only as products of this invocation's
+disposable configure/generate step, and the reader nevertheless completes all
+record, identity, set, filename, and path validation before any consumer
+starts. Valid consumers then run in declaration order, and a runtime failure
 prevents later consumers from starting.
 
 When the selected CMake generator exposes multiple configurations, the smoke
 uses that same generator for producer and consumer, checks each
 `CMAKE_GENERATOR` and `CMAKE_CONFIGURATION_TYPES` cache value, and resolves the
-consumer executable from the configuration-specific `$<TARGET_FILE:...>`
-manifest.
+consumer executable from the configuration-specific `$<TARGET_FILE_NAME:...>`
+and `$<TARGET_FILE:...>` manifest fields.
 
 Migration residue, phase completion, stale-term, and source-layout checks are
 temporary development checks. They must not be registered with CTest or CI.
@@ -263,12 +279,18 @@ paths against disposable producer cache fixtures while replacing subprocess
 execution, so it verifies cache-to-child-argv propagation without launching a
 product configure, build, or install. Its data-driven command recorder also
 creates arbitrary 0/1/N dependency-disabled target declarations, target-file
-manifests, and fake executables. In-process cases require ordered execution and
+manifests, CMake-authoritative target filenames, and fake executables.
+In-process cases cover Linux/macOS extensionless names, Windows `.exe`, and
+POSIX-Python Cygwin/MSYS2 `.exe` spelling. They require ordered execution and
 pre-runtime failure for empty, duplicate, missing/unexpected, malformed,
-control-bearing, unsafe, noncanonical, unexpected-layout, unbuilt, non-file, or
-non-executable inventory records; build and consumer failures lock fail-fast
-ordering. A separate `cmake -P` fixture calls the production public-header
-writer directly and performs no project configure.
+control-bearing, separator-bearing, reserved, foreign,
+filename/path-drifted, unsafe, noncanonical, unexpected-layout, unbuilt,
+non-file, or non-executable inventory records; build and consumer failures lock
+fail-fast ordering. A compiler-free `project(... NONE)` fixture exercises the
+generated target validator and both target filename/path expressions. A
+separate `cmake -P` fixture calls the production public-header writer directly;
+neither fixture starts a compiler, product build, install, or generated
+executable.
 The same process injects executable lookup, validation, and captured-command
 callbacks into the static-product driver's production archive-symbol helpers.
 It locks Darwin xcrun-first fallback, non-Darwin independence, all-candidate

--- a/docs/development/zh/Testing-and-Validation.zh.md
+++ b/docs/development/zh/Testing-and-Validation.zh.md
@@ -151,20 +151,32 @@ capability profile 后才可复用该 producer。
 
 生成的 clean consumer project 会维护一份有序的 CMake executable target list。同一份 list
 负责创建 target、写出 configure-time 精确 target declaration，并通过 `file(GENERATE)` 提供
-configuration-specific 的双字段
-`target<TAB>$<TARGET_FILE:target>` manifest。当前 profile 只声明
-`dependency_disabled_consumer`；新增另一个长期 consumer 时，只需扩展该 CMake list 与对应源码，
-无需在 Python 中增加 target name 或 discovery branch。Reader 要求两份 manifest 都非空、唯一且
-顺序完全相同，并拒绝字段 malformed、blank/comment record、无效 UTF-8、非结构性的 ASCII C0
-control 或 DEL、非 canonical target name，以及缺失、意外、重复或乱序的 target。每个解析出的
-executable 都必须使用 canonical native 拼写、位于 consumer build root 或所选 configuration
-目录、basename 与 target 匹配、不是 symlink，并且是可执行 regular file。整份 inventory 的
-collection、set 与 path 校验会在任何 consumer 启动前全部完成；有效 consumer 随后按声明顺序
-运行，某个 consumer 运行失败时，后续 consumer 不会启动。
+configuration-specific 的三字段
+`target<TAB>$<TARGET_FILE_NAME:target><TAB>$<TARGET_FILE:target>` manifest。当前 profile
+只声明 `dependency_disabled_consumer`；新增另一个长期 consumer 时，只需扩展该 CMake list 与
+对应源码，无需在 Python 中增加 target name 或 discovery branch。CMake 3.16 的 target generator
+expression 是 native 拼写的权威来源，因为它描述所选 generator、target platform 与
+configuration；Python 的 `os.name` 与 `sys.platform` 描述的是 interpreter host，不能据此推断
+executable suffix。尤其是，在 Cygwin 或 MSYS2 下运行的 POSIX Python 完全可能合法收到以
+`.exe` 结尾的 CMake target filename。
+
+Reader 要求两份 manifest 都非空、唯一，并且 target 顺序完全相同。它会拒绝字段数量 malformed、
+empty field、blank/comment record、无效 UTF-8、非结构性的 ASCII C0 control 或 DEL、非 canonical
+target name，以及缺失、意外、重复或乱序的 target。Configured filename 不得包含 POSIX 或
+Windows separator，不得为 `.` 或 `..`，必须唯一，并且只能精确等于 target name 或该名称加
+`.exe`。这是全部可用的 native 拼写，因为生成的 consumer 不会定制 `OUTPUT_NAME`、prefix、
+suffix 或 configuration postfix。这项 target-to-filename 绑定会阻止伪造的新字段选择任意
+build-local executable。完整 target path 必须使用 canonical native 拼写、保持唯一、位于
+consumer build root 或所选 configuration 目录，其 basename 与 CMake 声明的 filename 精确相等，
+同时不得是 symlink，且必须指向可执行 regular file。两份 manifest 只有作为本次调用的可丢弃
+configure/generate step 的产物才会被接受；即便如此，reader 仍会在任何 consumer 启动前完成
+全部 record、identity、set、filename 与 path 校验。有效 consumer 随后按声明顺序运行；某个
+consumer 运行失败时，后续 consumer 不会启动。
 
 当所选 CMake generator 提供多个 configuration 时，smoke 会为 producer 与 consumer 使用同一个
 generator，检查两侧的 `CMAKE_GENERATOR` 和 `CMAKE_CONFIGURATION_TYPES` cache 值，并从
-configuration-specific `$<TARGET_FILE:...>` manifest 解析 consumer 可执行文件。
+configuration-specific manifest 的 `$<TARGET_FILE_NAME:...>` 与 `$<TARGET_FILE:...>` 字段
+解析 consumer 可执行文件。
 
 迁移 residue、phase 完成度、陈旧术语与源码布局检查是临时开发检查，不得注册到 CTest 或 CI。
 Issue 专属 replay、provenance、helper 和 output artifact 既不得进入 primary repository，也不得
@@ -197,11 +209,15 @@ executable。
 fixture 执行三个 install-consumer driver 的真实命令构造路径，同时替换 subprocess 执行，因此能
 在不启动 product configure、build 或 install 的情况下验证 cache 到 child argv 的传播。其
 data-driven command recorder 还会创建任意 0/1/N dependency-disabled target declaration、
-target-file manifest 与 fake executable。进程内 case 要求按序执行，并要求 empty、duplicate、
-missing/unexpected、malformed、含 control、unsafe、noncanonical、unexpected-layout、unbuilt、
-non-file 或 non-executable inventory record 在 runtime 前失败；build 与 consumer failure 还会锁定
-fail-fast 顺序。另一项 `cmake -P` fixture 会直接调用 production public-header writer，并且不会
-执行 project configure。
+target-file manifest、由 CMake 提供权威值的 target filename 与 fake executable。进程内 case
+覆盖 Linux/macOS 的无后缀名称、Windows `.exe`，以及 POSIX Python 下 Cygwin/MSYS2 的 `.exe`
+拼写。它们要求按序执行，并要求 empty、duplicate、missing/unexpected、malformed、含 control、
+含 separator、reserved、foreign、filename/path drift、unsafe、noncanonical、unexpected-layout、
+unbuilt、non-file 或 non-executable inventory record 在 runtime 前失败；build 与 consumer
+failure 还会锁定 fail-fast 顺序。一项 compiler-free `project(... NONE)` fixture 会执行生成的
+target validator 与两种 target filename/path expression；另一项 `cmake -P` fixture 会直接调用
+production public-header writer。两者都不会启动 compiler、product build、install 或生成的
+executable。
 同一进程还会向 static-product driver 的 production archive-symbol helper 注入 executable lookup、
 validation 与 captured-command callback；它会在不改变进程 PATH、也不取代真实 installed archive
 scan 的前提下，锁定 Darwin xcrun-first fallback、非 Darwin 独立性、全部 candidate failure 与

--- a/tests/integration/dependency_disabled_install_smoke.py
+++ b/tests/integration/dependency_disabled_install_smoke.py
@@ -32,9 +32,11 @@ CONSUMER_TARGET_DECLARATION_HEADER = "# target"
 #:   reader; CMake uses the matching ``$<CONFIG>`` expression when generating.
 CONSUMER_TARGET_FILE_MANIFEST_PREFIX = "consumer_target_files-"
 #: @brief Exact first record required by the target-file TSV manifest.
-#: @note No comment, blank, or repeated-header record is legal after this line.
+#: @note Each later record binds one target to CMake's configured target
+#:   filename and full target path. No comment, blank, or repeated-header
+#:   record is legal after this line.
 CONSUMER_TARGET_FILE_MANIFEST_HEADER = (
-    "# target\tconfigured executable"
+    "# target\tconfigured executable filename\tconfigured executable"
 )
 #: @brief Lexical local executable-target spelling shared with CMake.
 #: @note Semantic validation separately excludes ``.``, ``..``, imported/alias
@@ -61,20 +63,34 @@ def is_canonical_consumer_target_name(target_name: str) -> bool:
     )
 
 
-def native_consumer_executable_basename(target_name: str) -> str:
-    """@brief Derive the sole native executable basename for one target.
+def is_canonical_consumer_target_filename(
+    target_name: str, executable_name: str
+) -> bool:
+    """@brief Validate CMake's configured filename for one local target.
 
-    @param target_name Canonical local target name already validated by the
-      caller.
-    @return ``target_name.exe`` on native Windows Python, otherwise the exact
-      extensionless ``target_name`` spelling.
-    @throws None The result is derived only from ``os.name`` and the input.
-    @note Accepting exactly one host-native spelling prevents a POSIX manifest
-      from substituting a foreign ``.exe`` path, or Windows from substituting
-      an extensionless path, for CMake's ``$<TARGET_FILE:...>`` result.
+    @param target_name Exact canonical target identity from both manifests.
+    @param executable_name Configuration-specific ``$<TARGET_FILE_NAME>``
+      field emitted by the generated CMake project.
+    @return True only for the extensionless target spelling or that exact
+      spelling plus the native Windows/Cygwin/MSYS2 ``.exe`` suffix.
+    @throws None Validation is deterministic and performs no host-platform
+      classification or I/O.
+    @note The generated consumer does not customize ``OUTPUT_NAME``, prefix,
+      suffix, or configuration postfix. CMake, rather than Python's
+      ``os.name`` or ``sys.platform``, therefore chooses which of the two
+      target-bound native spellings is authoritative. Requiring that closed
+      relationship prevents a forged filename field from selecting an
+      arbitrary build-local executable.
     """
 
-    return f"{target_name}.exe" if os.name == "nt" else target_name
+    return (
+        is_canonical_consumer_target_name(target_name)
+        and executable_name not in {"", ".", ".."}
+        and not contains_forbidden_ascii_control(executable_name)
+        and PurePosixPath(executable_name).name == executable_name
+        and PureWindowsPath(executable_name).name == executable_name
+        and executable_name in {target_name, f"{target_name}.exe"}
+    )
 
 
 def run(command: list[str], cwd: Path) -> None:
@@ -239,12 +255,14 @@ def configured_consumer_target_files(
     """@brief Validate and resolve every declared consumer executable.
 
     The reader first parses the configure-time target declaration and the
-    configuration-specific ``$<TARGET_FILE:...>`` TSV independently. It then
-    requires the same nonempty unique target sequence before validating every
-    executable path. Paths must use canonical native spelling, resolve without
-    a symlink inside the current consumer build, use the target's sole native
-    executable basename, and identify an executable regular file. Only after
-    the complete inventory passes does the function return any runnable path.
+    configuration-specific ``$<TARGET_FILE_NAME:...>`` plus
+    ``$<TARGET_FILE:...>`` TSV independently. It then requires the same
+    nonempty unique target sequence before validating every executable name
+    and path. Configured names must remain target-bound native spellings;
+    paths must use canonical native spelling, resolve without a symlink inside
+    the current consumer build, match the configured name exactly, and
+    identify an executable regular file. Only after the complete inventory
+    passes does the function return any runnable path.
 
     @param build Configured and built disposable consumer build directory.
     @param configuration Exact configuration selected by the consumer build.
@@ -301,18 +319,22 @@ def configured_consumer_target_files(
         allow_tab=True,
         description="dependency-disabled consumer target-file inventory",
     )
-    serialized_records: list[tuple[str, str]] = []
+    serialized_records: list[tuple[str, str, str]] = []
     serialized_target_set: set[str] = set()
+    serialized_filename_set: set[str] = set()
     for line_number, line in enumerate(target_file_lines, start=2):
         fields = line.split("\t")
-        if len(fields) != 2:
+        if len(fields) != 3:
             raise RuntimeError(
                 "dependency-disabled consumer target-file inventory contains "
                 f"a malformed entry at line {line_number}"
             )
-        target_name, executable_text = fields
+        target_name, executable_name, executable_text = fields
         if (
             not is_canonical_consumer_target_name(target_name)
+            or not is_canonical_consumer_target_filename(
+                target_name, executable_name
+            )
             or not executable_text
         ):
             raise RuntimeError(
@@ -324,14 +346,24 @@ def configured_consumer_target_files(
                 "dependency-disabled consumer target-file inventory contains "
                 f"a duplicate target: {target_name!r}"
             )
+        if executable_name in serialized_filename_set:
+            raise RuntimeError(
+                "dependency-disabled consumer target-file inventory contains "
+                "a duplicate configured executable filename"
+            )
         serialized_target_set.add(target_name)
-        serialized_records.append((target_name, executable_text))
+        serialized_filename_set.add(executable_name)
+        serialized_records.append(
+            (target_name, executable_name, executable_text)
+        )
     if not serialized_records:
         raise RuntimeError(
             "dependency-disabled consumer target-file inventory is empty"
         )
 
-    serialized_targets = [target for target, _path in serialized_records]
+    serialized_targets = [
+        target for target, _filename, _path in serialized_records
+    ]
     missing_targets = [
         target
         for target in declared_targets
@@ -353,7 +385,7 @@ def configured_consumer_target_files(
 
     resolved_records: list[tuple[str, Path]] = []
     resolved_path_set: set[Path] = set()
-    for target_name, executable_text in serialized_records:
+    for target_name, executable_name, executable_text in serialized_records:
         executable = Path(executable_text)
         if not executable.is_absolute():
             raise RuntimeError(
@@ -399,15 +431,11 @@ def configured_consumer_target_files(
                 "dependency-disabled consumer target-file inventory escapes "
                 f"the consumer build for target {target_name!r}"
             ) from error
-        expected_executable_name = native_consumer_executable_basename(
-            target_name
-        )
-        if resolved_executable.name != expected_executable_name:
+        if resolved_executable.name != executable_name:
             raise RuntimeError(
                 "dependency-disabled consumer target-file inventory path does "
                 f"not match target {target_name!r}"
             )
-        executable_name = resolved_executable.name
         if build_relative_executable not in {
             Path(executable_name),
             Path(configuration) / executable_name,
@@ -587,11 +615,12 @@ def write_consumer(source: Path) -> None:
     @return None.
     @throws OSError If source files cannot be written.
     @note One CMake target list owns validated executable creation, declaration
-      order, and the configuration-specific ``$<TARGET_FILE:...>`` manifest.
-      Reserved dot spellings and typed ``_NOT_BUILT`` sentinels fail before
-      target creation or serialization. The current executable verifies neutral
-      allocation, empty-session lifecycle, and explicit persistence failure
-      without parser or image-library APIs.
+      order, and the configuration-specific ``$<TARGET_FILE_NAME:...>`` plus
+      ``$<TARGET_FILE:...>`` manifest. Reserved dot spellings and typed
+      ``_NOT_BUILT`` sentinels fail before target creation or serialization.
+      The current executable verifies neutral allocation, empty-session
+      lifecycle, and explicit persistence failure without parser or
+      image-library APIs.
     """
 
     source.mkdir(parents=True)
@@ -615,7 +644,10 @@ def write_consumer(source: Path) -> None:
                 "set(PHOTOSPIDER_DEPENDENCY_DISABLED_CONSUMER_DECLARATION",
                 '  "# target\\n")',
                 "set(PHOTOSPIDER_DEPENDENCY_DISABLED_CONSUMER_TARGET_FILES",
-                '  "# target\\tconfigured executable\\n")',
+                (
+                    '  "# target\\tconfigured executable filename\\t'
+                    'configured executable\\n")'
+                ),
                 "foreach(PHOTOSPIDER_DEPENDENCY_DISABLED_CONSUMER_TARGET",
                 "    IN LISTS",
                 "      PHOTOSPIDER_DEPENDENCY_DISABLED_CONSUMER_TARGETS)",
@@ -654,6 +686,10 @@ def write_consumer(source: Path) -> None:
                 "  string(APPEND",
                 "    PHOTOSPIDER_DEPENDENCY_DISABLED_CONSUMER_TARGET_FILES",
                 "    \"${PHOTOSPIDER_DEPENDENCY_DISABLED_CONSUMER_TARGET}\\t\"",
+                (
+                    "    \"$<TARGET_FILE_NAME:${PHOTOSPIDER_DEPENDENCY_"
+                    "DISABLED_CONSUMER_TARGET}>\\t\""
+                ),
                 (
                     "    \"$<TARGET_FILE:${PHOTOSPIDER_DEPENDENCY_DISABLED_"
                     "CONSUMER_TARGET}>\\n\")"

--- a/tests/integration/install_consumer_architecture_propagation_test.py
+++ b/tests/integration/install_consumer_architecture_propagation_test.py
@@ -401,6 +401,7 @@ def write_consumer_target_inventory_fixture(
     declared_targets: tuple[str, ...],
     *,
     mapped_targets: tuple[str, ...] | None = None,
+    configured_filename_by_target: dict[str, str] | None = None,
     target_file_payload: str | None = None,
 ) -> dict[str, pathlib.Path]:
     """@brief Create one CMake-shaped consumer target inventory fixture.
@@ -410,6 +411,9 @@ def write_consumer_target_inventory_fixture(
     @param declared_targets Ordered target sequence written by CMake configure.
     @param mapped_targets Optional ordered target-file sequence; omitted values
       use ``declared_targets`` exactly.
+    @param configured_filename_by_target Optional CMake-authoritative target
+      filenames keyed by mapped target. Omitted entries use the extensionless
+      target spelling without consulting the Python host family.
     @param target_file_payload Optional complete TSV override used by malformed
       fail-closed cases after executable files are synthesized.
     @return Target names mapped to canonical executable fixture paths.
@@ -440,10 +444,13 @@ def write_consumer_target_inventory_fixture(
     effective_mapped_targets = (
         declared_targets if mapped_targets is None else mapped_targets
     )
+    effective_configured_filenames = dict(
+        configured_filename_by_target or {}
+    )
     executable_by_target: dict[str, pathlib.Path] = {}
     for target_name in effective_mapped_targets:
-        executable_name = (
-            f"{target_name}.exe" if os.name == "nt" else target_name
+        executable_name = effective_configured_filenames.get(
+            target_name, target_name
         )
         executable = (build / executable_name).resolve()
         executable.write_text("synthetic consumer executable\n", encoding="utf-8")
@@ -454,7 +461,9 @@ def write_consumer_target_inventory_fixture(
             dependency_disabled.CONSUMER_TARGET_FILE_MANIFEST_HEADER
             + "\n"
             + "".join(
-                f"{target}\t{executable_by_target[target]}\n"
+                f"{target}\t"
+                f"{effective_configured_filenames.get(target, target)}\t"
+                f"{executable_by_target[target]}\n"
                 for target in effective_mapped_targets
             )
         )
@@ -676,9 +685,10 @@ class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):
     @throws AssertionError If valid 1/N inventories drift, malformed or unsafe
       data is accepted, or driver command ordering changes.
     @note Driver cases reuse a synthetic validated producer and replace process
-      execution with ``CommandRecorder``. One compiler-free configure probes
-      the actual generated CMake target validator; no compiler, installed
-      product, or generated consumer executable is launched.
+      execution with ``CommandRecorder``. Compiler-free configures probe the
+      actual generated CMake target validator and target filename/path writer;
+      no compiler, installed product, or generated consumer executable is
+      launched.
     """
 
     #: @brief CMake launcher used only by the generated-writer rejection case.
@@ -870,6 +880,108 @@ class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):
                         list(inventory_directory.glob("*.tsv")), []
                     )
 
+    def test_generated_writer_emits_cmake_filename_and_path_fields(
+        self,
+    ) -> None:
+        """@brief Round-trip both target-file expressions through CMake.
+
+        @return None after the production serialization loop emits target,
+          ``$<TARGET_FILE_NAME>``, and ``$<TARGET_FILE>`` as three exact TSV
+          fields for a POSIX-Python ``.exe`` imported target fixture.
+        @throws OSError If fixture files cannot be written or CMake cannot
+          start.
+        @throws subprocess.CalledProcessError If CMake rejects the valid
+          compiler-free generated project.
+        @throws AssertionError If the writer omits, reorders, or changes either
+          configuration-specific target-file expression.
+        @note The fixture replaces only target construction and package lookup
+          with an imported executable. The production target list, validation,
+          declaration, and manifest serialization remain unchanged.
+        """
+
+        with tempfile.TemporaryDirectory(
+            prefix="photospider-consumer-target-writer-fields-"
+        ) as temporary:
+            sandbox = pathlib.Path(temporary).resolve()
+            source = sandbox / "source"
+            build = sandbox / "build"
+            dependency_disabled.write_consumer(source)
+            cmake_lists = source / "CMakeLists.txt"
+            cmake_text = cmake_lists.read_text(encoding="utf-8")
+            target_variable = (
+                "${PHOTOSPIDER_DEPENDENCY_DISABLED_CONSUMER_TARGET}"
+            )
+            target_creation = (
+                "  add_executable(\n"
+                f'    "{target_variable}"\n'
+                f'    "{target_variable}.cpp")\n'
+                "  target_link_libraries(\n"
+                f'    "{target_variable}"\n'
+                "    PRIVATE Photospider::photospider)"
+            )
+            imported_target_creation = (
+                "  add_executable(\n"
+                f'    "{target_variable}" IMPORTED)\n'
+                "  set_target_properties(\n"
+                f'    "{target_variable}" PROPERTIES\n'
+                "    IMPORTED_LOCATION\n"
+                f'      "${{CMAKE_BINARY_DIR}}/{target_variable}.exe")'
+            )
+            replacements = (
+                (
+                    "project(dependency_disabled_consumer LANGUAGES CXX)",
+                    "project(dependency_disabled_consumer NONE)",
+                ),
+                (
+                    "find_package(Photospider CONFIG REQUIRED "
+                    "COMPONENTS embedded)",
+                    "# Package lookup omitted by compiler-free writer fixture.",
+                ),
+                (target_creation, imported_target_creation),
+            )
+            for original, replacement in replacements:
+                self.assertIn(original, cmake_text)
+                cmake_text = cmake_text.replace(original, replacement, 1)
+            write_exact_text(cmake_lists, cmake_text)
+
+            subprocess.run(
+                [
+                    self.cmake_executable,
+                    "-S",
+                    str(source),
+                    "-B",
+                    str(build),
+                    "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            target_file_manifest = (
+                dependency_disabled.consumer_target_file_manifest_path(
+                    build, "RelWithDebInfo"
+                )
+            )
+            records = dependency_disabled.read_strict_manifest_lines(
+                target_file_manifest,
+                expected_header=(
+                    dependency_disabled.CONSUMER_TARGET_FILE_MANIFEST_HEADER
+                ),
+                allow_tab=True,
+                description="compiler-free target-file inventory fixture",
+            )
+            self.assertEqual(len(records), 1)
+            target_name, configured_filename, configured_path = (
+                records[0].split("\t")
+            )
+            self.assertEqual(target_name, "dependency_disabled_consumer")
+            self.assertEqual(
+                configured_filename, "dependency_disabled_consumer.exe"
+            )
+            self.assertEqual(
+                pathlib.Path(configured_path).name, configured_filename
+            )
+
     def test_rejects_reserved_dot_names_in_both_manifests(self) -> None:
         """@brief Reject ``.`` and ``..`` in each independent target field.
 
@@ -933,6 +1045,7 @@ class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):
                                 dependency_disabled.CONSUMER_TARGET_FILE_MANIFEST_HEADER
                                 + "\n"
                                 + f"{reserved_target}\t"
+                                + f"{target_name}\t"
                                 + f"{executable_by_target[target_name]}\n"
                             )
                             expected_diagnostic = "target-file inventory"
@@ -944,63 +1057,147 @@ class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):
                                 build, "RelWithDebInfo"
                             )
 
-    def test_native_executable_basename_uses_host_family(self) -> None:
-        """@brief Lock exact POSIX and Windows target-file basename spelling.
+    def test_accepts_cmake_authoritative_native_filename_spellings(
+        self,
+    ) -> None:
+        """@brief Accept native target filenames without Python host guessing.
 
-        @return None after POSIX yields the extensionless target and Windows
-          yields exactly the target plus ``.exe``.
-        @throws AssertionError If the platform-specific helper accepts a shared
-          two-spelling policy or returns another suffix.
-        @note ``os.name`` is replaced only while calling the pure string helper;
+        @return None after Linux/macOS extensionless names, Windows ``.exe``,
+          and Cygwin/MSYS2 POSIX-Python ``.exe`` names all satisfy the same
+          target-bound contract.
+        @throws AssertionError If filename validation consults ``os.name`` or
+          rejects one of CMake's two uncustomized native spellings.
+        @note ``os.name`` is varied only around the pure filename validator;
           no platform-specific ``Path`` object is constructed under the mock.
         """
 
-        with mock.patch.object(dependency_disabled.os, "name", "posix"):
-            self.assertEqual(
-                dependency_disabled.native_consumer_executable_basename(
-                    "consumer_safe"
-                ),
-                "consumer_safe",
-            )
-        with mock.patch.object(dependency_disabled.os, "name", "nt"):
-            self.assertEqual(
-                dependency_disabled.native_consumer_executable_basename(
-                    "consumer_safe"
-                ),
-                "consumer_safe.exe",
-            )
+        target_name = "consumer_safe"
+        profiles = (
+            ("linux", "posix", target_name),
+            ("macos", "posix", target_name),
+            ("windows", "nt", f"{target_name}.exe"),
+            ("cygwin", "posix", f"{target_name}.exe"),
+            ("msys2", "posix", f"{target_name}.exe"),
+        )
+        for profile, python_os_name, configured_filename in profiles:
+            with self.subTest(profile=profile):
+                with mock.patch.object(
+                    dependency_disabled.os, "name", python_os_name
+                ):
+                    self.assertTrue(
+                        dependency_disabled.is_canonical_consumer_target_filename(
+                            target_name, configured_filename
+                        )
+                    )
 
-    def test_rejects_non_native_executable_basename(self) -> None:
-        """@brief Reject a foreign-platform basename for an otherwise safe file.
+    def test_reader_accepts_cmake_declared_exe_without_host_guessing(
+        self,
+    ) -> None:
+        """@brief Accept CMake's ``.exe`` without host suffix inference.
 
-        @return None after POSIX rejects ``target.exe`` or Windows rejects the
-          extensionless ``target`` spelling before returning an executable.
-        @throws OSError If the synthetic executable or manifest cannot be
+        @return None after the complete reader accepts an executable whose
+          CMake-declared filename and path basename both end in ``.exe``.
+        @throws OSError If synthetic manifests or executable files cannot be
           written.
-        @throws AssertionError If the reader accepts both platform spellings.
-        @note The path remains absolute, canonical, in-root, regular, and
-          executable so basename policy is the sole failing invariant.
+        @throws AssertionError If reader behavior still derives suffix policy
+          from the Python host family.
+        @note On Windows this is the native target spelling. On Linux/macOS it
+          deterministically simulates the POSIX-Python/CMake-target split used
+          by Cygwin and MSYS2.
         """
 
         with tempfile.TemporaryDirectory(
-            prefix="photospider-consumer-target-nonnative-basename-"
+            prefix="photospider-consumer-target-posix-cmake-exe-"
         ) as temporary:
             build = pathlib.Path(temporary).resolve() / "build"
             target_name = "consumer_safe"
-            write_consumer_target_inventory_fixture(
+            configured_filename = f"{target_name}.exe"
+            executable_by_target = write_consumer_target_inventory_fixture(
                 build,
                 "RelWithDebInfo",
                 (target_name,),
+                configured_filename_by_target={
+                    target_name: configured_filename
+                },
             )
-            non_native_name = (
-                target_name if os.name == "nt" else f"{target_name}.exe"
+            self.assertIn(dependency_disabled.os.name, {"nt", "posix"})
+            self.assertEqual(
+                dependency_disabled.configured_consumer_target_files(
+                    build, "RelWithDebInfo"
+                ),
+                [(target_name, executable_by_target[target_name])],
             )
-            non_native_executable = build / non_native_name
-            non_native_executable.write_text(
-                "synthetic non-native consumer executable\n",
-                encoding="utf-8",
+
+    def test_rejects_foreign_tampered_and_drifted_filenames(self) -> None:
+        """@brief Reject unbound, unsafe, or path-drifted filename fields.
+
+        @return None after separators, reserved names, a typed sentinel,
+          foreign target/suffix spellings, and filename/path basename drift
+          all fail before returning an executable.
+        @throws OSError If synthetic manifests or executable files cannot be
+          written.
+        @throws AssertionError If the new filename field can select an
+          arbitrary build-local executable or disagree with its path.
+        @note Every referenced path remains canonical, build-local, regular,
+          and executable so configured-filename validation is the sole policy
+          under test.
+        """
+
+        invalid_filenames = {
+            "posix-separator": "nested/consumer_safe",
+            "windows-separator": "nested\\consumer_safe",
+            "dot": ".",
+            "dotdot": "..",
+            "sentinel": "consumer_safe_NOT_BUILT",
+            "foreign-target": "consumer_foreign",
+            "foreign-suffix": "consumer_safe.bin",
+        }
+        with tempfile.TemporaryDirectory(
+            prefix="photospider-consumer-target-tampered-filename-"
+        ) as temporary:
+            sandbox = pathlib.Path(temporary).resolve()
+            target_name = "consumer_safe"
+            for case_name, configured_filename in invalid_filenames.items():
+                with self.subTest(case=case_name):
+                    build = sandbox / case_name
+                    executable_by_target = (
+                        write_consumer_target_inventory_fixture(
+                            build,
+                            "RelWithDebInfo",
+                            (target_name,),
+                        )
+                    )
+                    manifest = (
+                        dependency_disabled.consumer_target_file_manifest_path(
+                            build, "RelWithDebInfo"
+                        )
+                    )
+                    write_exact_text(
+                        manifest,
+                        (
+                            dependency_disabled.CONSUMER_TARGET_FILE_MANIFEST_HEADER
+                            + "\n"
+                            + f"{target_name}\t{configured_filename}\t"
+                            + f"{executable_by_target[target_name]}\n"
+                        ),
+                    )
+                    with self.assertRaisesRegex(
+                        RuntimeError, "target-file inventory"
+                    ):
+                        dependency_disabled.configured_consumer_target_files(
+                            build, "RelWithDebInfo"
+                        )
+
+            build = sandbox / "path-name-drift"
+            cmake_filename = f"{target_name}.exe"
+            executable_by_target = write_consumer_target_inventory_fixture(
+                build,
+                "RelWithDebInfo",
+                (target_name,),
+                configured_filename_by_target={
+                    target_name: cmake_filename
+                },
             )
-            non_native_executable.chmod(0o755)
             manifest = dependency_disabled.consumer_target_file_manifest_path(
                 build, "RelWithDebInfo"
             )
@@ -1009,10 +1206,45 @@ class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):
                 (
                     dependency_disabled.CONSUMER_TARGET_FILE_MANIFEST_HEADER
                     + "\n"
-                    + f"{target_name}\t{non_native_executable}\n"
+                    + f"{target_name}\t{target_name}\t"
+                    + f"{executable_by_target[target_name]}\n"
                 ),
             )
             with self.assertRaisesRegex(RuntimeError, "does not match target"):
+                dependency_disabled.configured_consumer_target_files(
+                    build, "RelWithDebInfo"
+                )
+
+    def test_rejects_duplicate_configured_filename(self) -> None:
+        """@brief Reject two target identities mapped to one filename.
+
+        @return None after individually target-bound spellings collide and the
+          reader rejects the duplicate before returning an executable.
+        @throws OSError If synthetic manifests or executable files cannot be
+          written.
+        @throws AssertionError If filename identity can collapse across two
+          unique declared targets.
+        @note ``consumer_a.exe`` is legal both as the Windows filename of
+          ``consumer_a`` and the extensionless filename of target
+          ``consumer_a.exe``; their collision must nevertheless fail closed.
+        """
+
+        with tempfile.TemporaryDirectory(
+            prefix="photospider-consumer-target-duplicate-filename-"
+        ) as temporary:
+            build = pathlib.Path(temporary).resolve() / "build"
+            targets = ("consumer_a", "consumer_a.exe")
+            write_consumer_target_inventory_fixture(
+                build,
+                "RelWithDebInfo",
+                targets,
+                configured_filename_by_target={
+                    target: "consumer_a.exe" for target in targets
+                },
+            )
+            with self.assertRaisesRegex(
+                RuntimeError, "duplicate configured executable filename"
+            ):
                 dependency_disabled.configured_consumer_target_files(
                     build, "RelWithDebInfo"
                 )
@@ -1059,7 +1291,8 @@ class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):
 
         @return None after missing/invalid headers, blank/comments, field-count
           drift, empty fields, invalid target names, missing final LF, invalid
-          UTF-8, NUL, every remaining C0 control, and DEL all fail.
+          UTF-8, and every C0 control plus DEL in both target and configured
+          filename fields all fail.
         @throws OSError If malformed manifest bytes cannot be written.
         @throws AssertionError If any malformed payload is accepted.
         @note LF and TAB injection cases use structurally malformed records;
@@ -1079,6 +1312,9 @@ class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):
             )
             executable = executable_by_target[target_name]
             header = dependency_disabled.CONSUMER_TARGET_FILE_MANIFEST_HEADER
+            valid_record = (
+                f"{target_name}\t{target_name}\t{executable}\n"
+            )
             manifest = dependency_disabled.consumer_target_file_manifest_path(
                 build, "RelWithDebInfo"
             )
@@ -1086,37 +1322,58 @@ class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):
                 "empty": "",
                 "header-only": f"{header}\n",
                 "wrong-header": (
-                    f"# targets\n{target_name}\t{executable}\n"
+                    f"# targets\n{valid_record}"
                 ),
                 "repeated-header": (
-                    f"{header}\n{header}\n"
-                    f"{target_name}\t{executable}\n"
+                    f"{header}\n{header}\n{valid_record}"
                 ),
                 "comment": (
-                    f"{header}\n# later comment\n"
-                    f"{target_name}\t{executable}\n"
+                    f"{header}\n# later comment\n{valid_record}"
                 ),
-                "blank": (
-                    f"{header}\n\n{target_name}\t{executable}\n"
-                ),
+                "blank": f"{header}\n\n{valid_record}",
                 "one-field": f"{header}\n{target_name}\n",
-                "three-fields": (
-                    f"{header}\n{target_name}\t{executable}\textra\n"
+                "two-fields": (
+                    f"{header}\n{target_name}\t{target_name}\n"
                 ),
-                "empty-target": f"{header}\n\t{executable}\n",
-                "empty-path": f"{header}\n{target_name}\t\n",
-                "alias-target": f"{header}\nconsumer::alias\t{executable}\n",
+                "four-fields": (
+                    f"{header}\n{target_name}\t{target_name}\t"
+                    f"{executable}\textra\n"
+                ),
+                "empty-target": (
+                    f"{header}\n\t{target_name}\t{executable}\n"
+                ),
+                "empty-filename": (
+                    f"{header}\n{target_name}\t\t{executable}\n"
+                ),
+                "empty-path": (
+                    f"{header}\n{target_name}\t{target_name}\t\n"
+                ),
+                "alias-target": (
+                    f"{header}\nconsumer::alias\t{target_name}\t"
+                    f"{executable}\n"
+                ),
                 "sentinel-target": (
-                    f"{header}\n{target_name}_NOT_BUILT\t{executable}\n"
+                    f"{header}\n{target_name}_NOT_BUILT\t{target_name}\t"
+                    f"{executable}\n"
                 ),
                 "missing-final-lf": (
-                    f"{header}\n{target_name}\t{executable}"
+                    f"{header}\n{target_name}\t{target_name}\t{executable}"
                 ),
             }
             malformed_payloads.update(
                 {
-                    f"control-{control_code}": (
+                    f"target-control-{control_code}": (
                         f"{header}\nconsumer"
+                        f"{chr(control_code)}injected\t{target_name}\t"
+                        f"{executable}\n"
+                    )
+                    for control_code in (*range(32), 127)
+                }
+            )
+            malformed_payloads.update(
+                {
+                    f"filename-control-{control_code}": (
+                        f"{header}\n{target_name}\tconsumer"
                         f"{chr(control_code)}injected\t{executable}\n"
                     )
                     for control_code in (*range(32), 127)
@@ -1231,7 +1488,8 @@ class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):
                         (
                             dependency_disabled.CONSUMER_TARGET_FILE_MANIFEST_HEADER
                             + "\n"
-                            + f"{target_name}\t{rejected_path}\n"
+                            + f"{target_name}\t{target_name}\t"
+                            + f"{rejected_path}\n"
                         ),
                     )
                     with self.assertRaisesRegex(
@@ -1331,7 +1589,7 @@ class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):
                         malformed_payload = (
                             dependency_disabled.CONSUMER_TARGET_FILE_MANIFEST_HEADER
                             + "\n"
-                            + f"{target_name}\t../outside\n"
+                            + f"{target_name}\t{target_name}\t../outside\n"
                         )
                         recorder = CommandRecorder(
                             {consumer_build: (target_name,)},


### PR DESCRIPTION
## 概要

- 将 dependency-disabled consumer manifest 从两字段升级为三字段：target、CMake 配置后的原生文件名、CMake 配置后的完整路径。
- 由 `$<TARGET_FILE_NAME:...>` 与 `$<TARGET_FILE:...>` 提供权威拼写，Python 不再依据 `os.name` 或 `sys.platform` 推断 `.exe`。
- 保留闭合的 target↔filename↔path basename 绑定、根目录约束、symlink/non-file/non-executable/重复记录等 fail-closed 边界。
- 同步英文 Testing-and-Validation 文档及中文镜像，补充 Linux、macOS、Windows、Cygwin/MSYS2 测试矩阵。

## 审核追溯

本 PR 修复 PR #120 review thread `PRRT_kwDOPb1Wc86VnLea`、REST comment `3695239215` 提出的 native-basename P2。

这是 #117 的 CI 基线后续；本 PR 有意不关闭 #117。

## 本机验证

- 两个 Python 文件 `py_compile`：通过。
- `install_consumer_architecture_propagation_test.py`：36 项通过，1 项设计内 live-CTest 跳过。
- 新增/关键 filename 与 path 反例：7/7 通过；独立审核定向反例 13/13 通过。
- focused real CTest：`DependencyDisabledInstallSmoke` 与 `InstallConsumerArchitecturePropagationSafety` 均通过。
- 唯一 clean configure 与唯一 no-target full build：通过。
- ordinary CTest/JUnit：845/845 通过，0 失败，1 项预期跳过；JUnit SHA-256 `dbbfadfc6a1957daf210512ac8bb551f435f9c54356c80addacc7f52072ffad7`。
- 严格 inventory 发现的 6 个 `build-smoke` 均通过。
- Bash 5 healthcheck：18 项 change classification、15 项 inventory 单测、9 项 runtime capability、32 项 CI routing 全部通过。

## 远端门禁与审核

- 精确 HEAD `017d593bc053972a3dfe23cfaa95c3d0d58d7a72` 的 [CI Healthcheck](https://github.com/kevin-zf1123/photospider/actions/runs/30694189838) 与 [CI Integration](https://github.com/kevin-zf1123/photospider/actions/runs/30694189832) 均成功。
- Linux full CTest 843/843、全部 6 个 build-smoke、scripted CLI、propagation、plugin、execution-repeat 与 final integration gate 均成功。
- 全新独立审核：PASS，P0/P1/P2/P3 = 0/0/0/0；PR #121 review threads = 0。
- Codex 请求 comment `5150896986`；回复 comment `5150901669`，未发现阻塞问题。

## 风险

本地没有原生 Cygwin/MSYS2 执行环境；覆盖来自真实 CMake writer fixture、POSIX Python + `.exe` 模拟、manifest reader 端到端测试及远端安装 consumer smoke。该限制不阻塞本次确定性根因修复。
