### PR TITLE
chore(ci): add utf8proc development dependency

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -24,6 +24,7 @@ RUN if [ -n "$APT_MIRROR" ]; then \
     libgtest-dev \
     libopencv-dev \
     libssl-dev \
+    libutf8proc-dev \
     libyaml-cpp-dev \
     nlohmann-json3-dev \
     pkg-config \


### PR DESCRIPTION
## Summary

- Add `libutf8proc-dev` to the Ubuntu 24.04 CI image apt dependencies.
- Supply the utf8proc headers and library required by the B1 compilation path.
- Keep this PR isolated from the #95 refactor branch; no source, CMake, architecture, OpenSpec, or personal-overlay changes are included.

## Scope

This PR changes only `Dockerfile.ci`. It does not modify PR #122 or its base branch.

The authoritative CI documentation was reviewed. It describes image capabilities rather than an exact apt package inventory, so no documentation change is required for this package-only update.

## Local verification

On committed head `a1dd163ac44cb579f4f78b79b0433fd2d941c89a` against exact `origin/main` `34d49d9ff39c877172a81ed42b8339e8444c7ee7`:

- `CI_BASE_REF=origin/main CI_ARTIFACT_DIR=CI-results/healthcheck bash ci/scripts/healthcheck.sh`
  - PASS: `git diff --check`
  - PASS: 18 change-classification cases
  - PASS: 15 build-smoke inventory tests
  - PASS: 9 runtime capability cases
  - PASS: 32 CI routing cases
  - Skipped by design: clang-format and cpplint because no C++ files changed

Docker and architecture emulation were not run locally. The GitHub CI image build is the remote integration gate.