### PR TITLE
fix(ci): normalize trusted Darwin tmp spellings

### DIFF
--- a/docs/development/Testing-and-Validation.md
+++ b/docs/development/Testing-and-Validation.md
@@ -297,12 +297,17 @@ empty dependency surface. A neutral installed-package consumer then performs a
 real verbose compile and executable link. Its verbose output,
 `compile_commands.json`, link scripts, response files, evaluated imported-
 target properties, native symbols, and dependencies are scanned before the
-executable runs. The default and optional-component probes must remain usable,
-while a required absent component must fail with the Photospider-owned
-diagnostic before OpenEXR discovery. `OpenExrDeepProviderInstallConsumerSmoke`
-is the enabled companion: it installs the explicit component, loads the actual
-module, resolves both v3 exports, validates the API table, invokes provider
-destruction, and unloads the module.
+executable runs. Before marker classification, every exact audit root expands
+through the shared trusted Darwin mapping so `/tmp/...` and
+`/private/tmp/...` tool output are scrubbed as the same non-semantic prefix.
+No caller-controlled symlink is resolved, and library, header, symbol, and
+dependency names below the prefix remain visible to the scan. The default and
+optional-component probes must remain usable, while a required absent
+component must fail with the Photospider-owned diagnostic before OpenEXR
+discovery. `OpenExrDeepProviderInstallConsumerSmoke` is the enabled companion:
+it installs the explicit component, loads the actual module, resolves both v3
+exports, validates the API table, invokes provider destruction, and unloads
+the module.
 
 The generated clean consumer project maintains one ordered CMake executable
 target list. That same list creates the targets, writes a configure-time exact
@@ -332,12 +337,16 @@ configuration postfix. This target-to-filename binding prevents a forged new
 field from selecting an arbitrary build-local executable. The full target path
 must use canonical native spelling, remain unique, stay at the consumer build
 root or its selected configuration directory, have a basename exactly equal to
-the CMake-declared filename, avoid symlinks, and identify an executable regular
-file. Both manifests are accepted only as products of this invocation's
-disposable configure/generate step, and the reader nevertheless completes all
-record, identity, set, filename, and path validation before any consumer
-starts. Valid consumers then run in declaration order, and a runtime failure
-prevents later consumers from starting.
+the CMake-declared filename, and identify an executable regular file. On
+Darwin, only the shared root-owned `/tmp` alias and its physical
+`/private/tmp` root may provide alternate spellings of that same build-local
+suffix. The comparison never resolves a caller-controlled path into the
+trusted set, so every later intermediate component and the executable leaf
+must remain free of arbitrary symlinks. Both manifests are accepted only as
+products of this invocation's disposable configure/generate step, and the
+reader nevertheless completes all record, identity, set, filename, and path
+validation before any consumer starts. Valid consumers then run in declaration
+order, and a runtime failure prevents later consumers from starting.
 
 When the selected CMake generator exposes multiple configurations, the smoke
 uses that same generator for producer and consumer, checks each
@@ -1506,6 +1515,18 @@ failures propagate, and an `lstat`-style postcondition verifies that no
 directory or dangling link remains. The check/delete sequence is not an atomic
 cross-platform filesystem transaction, so these drivers accept only
 caller-owned transient subtrees whose components are not concurrently replaced.
+
+The same trusted-root inspector also serves two non-destructive consumers.
+`DependencyDisabledInstallSmoke` accepts a generated manifest target spelled
+under either trusted root only when strict resolution equals the shared
+physical spelling; an arbitrary intermediate or leaf symlink still differs and
+fails. `OpenExrDeepProviderOptionOffSmoke` expands only its exact audit roots to
+both trusted spellings before scrubbing tool evidence, preventing the smoke's
+own directory name from becoming an OpenEXR marker while leaving real
+dependency names scannable. `InstallConsumerArchitecturePropagationSafety`
+injects a synthetic mapping to lock bidirectional spelling, manifest
+acceptance, a post-root symlink counterexample, dual-spelling evidence scrub,
+and a real `-lOpenEXR` rejection on every platform without touching `/tmp`.
 
 `OpenCvOperationProviderBuildSmokeSafety` exercises those destructive guards,
 failure propagation, and postcondition only against a synthetic repository,

--- a/docs/development/Testing-and-Validation.md
+++ b/docs/development/Testing-and-Validation.md
@@ -307,7 +307,9 @@ component must fail with the Photospider-owned diagnostic before OpenEXR
 discovery. `OpenExrDeepProviderInstallConsumerSmoke` is the enabled companion:
 it installs the explicit component, loads the actual module, resolves both v3
 exports, validates the API table, invokes provider destruction, and unloads
-the module.
+the module. Its generated imported-provider path may use either trusted Darwin
+tmp spelling only when the strictly resolved physical file remains inside the
+installed prefix and every component after that prefix is free of symlinks.
 
 The generated clean consumer project maintains one ordered CMake executable
 target list. That same list creates the targets, writes a configure-time exact
@@ -1516,17 +1518,22 @@ directory or dangling link remains. The check/delete sequence is not an atomic
 cross-platform filesystem transaction, so these drivers accept only
 caller-owned transient subtrees whose components are not concurrently replaced.
 
-The same trusted-root inspector also serves two non-destructive consumers.
+The same trusted-root inspector also serves three non-destructive consumers.
 `DependencyDisabledInstallSmoke` accepts a generated manifest target spelled
 under either trusted root only when strict resolution equals the shared
 physical spelling; an arbitrary intermediate or leaf symlink still differs and
 fails. `OpenExrDeepProviderOptionOffSmoke` expands only its exact audit roots to
 both trusted spellings before scrubbing tool evidence, preventing the smoke's
 own directory name from becoming an OpenEXR marker while leaving real
-dependency names scannable. `InstallConsumerArchitecturePropagationSafety`
-injects a synthetic mapping to lock bidirectional spelling, manifest
-acceptance, a post-root symlink counterexample, dual-spelling evidence scrub,
-and a real `-lOpenEXR` rejection on every platform without touching `/tmp`.
+dependency names scannable. Its enabled companion accepts the generated
+provider target under either trusted spelling only after physical-prefix
+confinement and post-prefix component checks reject every later symlink or
+escape. `InstallConsumerArchitecturePropagationSafety` injects a synthetic
+mapping to lock bidirectional spelling, manifest acceptance, post-root symlink
+and escape counterexamples, dual-spelling evidence scrub, a real
+`-lOpenEXR` rejection, alias-spelled `libImath.dylib`/`libOpenEXR.dylib`
+rejections, and enabled-provider containment on every platform without
+touching `/tmp`.
 
 `OpenCvOperationProviderBuildSmokeSafety` exercises those destructive guards,
 failure propagation, and postcondition only against a synthetic repository,

--- a/docs/development/Testing-and-Validation.md
+++ b/docs/development/Testing-and-Validation.md
@@ -1518,6 +1518,12 @@ directory or dangling link remains. The check/delete sequence is not an atomic
 cross-platform filesystem transaction, so these drivers accept only
 caller-owned transient subtrees whose components are not concurrently replaced.
 
+The live install-consumer CTest inventory validator applies that same trusted
+mapping only to the exact maintained driver at command argv index two. The
+configured Python launcher and `-B` flag remain exact, while ordinary,
+intermediate, or leaf symlinks, parent traversal, and driver basename or layout
+drift remain outside the accepted candidate set.
+
 The same trusted-root inspector also serves three non-destructive consumers.
 `DependencyDisabledInstallSmoke` accepts a generated manifest target spelled
 under either trusted root only when strict resolution equals the shared

--- a/docs/development/zh/Testing-and-Validation.zh.md
+++ b/docs/development/zh/Testing-and-Validation.zh.md
@@ -226,8 +226,11 @@ undefined symbol surface 分别检查。Dynamic dependency 在 Darwin 使用 `ot
 surface 通过。随后，一个中立 installed-package consumer 会执行真实的 verbose compile 与
 executable link；在 executable 运行前，smoke 会扫描其 verbose output、
 `compile_commands.json`、link script、response file、求值后的 imported-target property、native
-symbol 与 dependency。Default 和 optional-component probe 必须继续可用；required absent
-component 必须先以 Photospider 自有诊断失败，不得发现 OpenEXR。
+symbol 与 dependency。在 marker 分类前，每个精确 audit root 都会通过共享的 Darwin 受信映射
+展开，因此工具输出中的 `/tmp/...` 与 `/private/tmp/...` 会作为同一个无语义 prefix 被 scrub。
+该过程不会解析 caller-controlled symlink，prefix 之下的 library、header、symbol 与 dependency
+名称仍对扫描可见。Default 和 optional-component probe 必须继续可用；required absent component
+必须先以 Photospider 自有诊断失败，不得发现 OpenEXR。
 `OpenExrDeepProviderInstallConsumerSmoke` 是启用态 companion：它安装显式 component，加载真实
 module，解析两个 v3 export，校验 API table，调用 provider destruction，然后卸载 module。
 
@@ -251,10 +254,13 @@ Windows separator，不得为 `.` 或 `..`，必须唯一，并且只能精确�
 suffix 或 configuration postfix。这项 target-to-filename 绑定会阻止伪造的新字段选择任意
 build-local executable。完整 target path 必须使用 canonical native 拼写、保持唯一、位于
 consumer build root 或所选 configuration 目录，其 basename 与 CMake 声明的 filename 精确相等，
-同时不得是 symlink，且必须指向可执行 regular file。两份 manifest 只有作为本次调用的可丢弃
-configure/generate step 的产物才会被接受；即便如此，reader 仍会在任何 consumer 启动前完成
-全部 record、identity、set、filename 与 path 校验。有效 consumer 随后按声明顺序运行；某个
-consumer 运行失败时，后续 consumer 不会启动。
+且必须指向可执行 regular file。在 Darwin 上，只有共享的 root-owned `/tmp` alias 及其物理
+`/private/tmp` root 可以为同一个 build-local suffix 提供不同拼写。比较过程绝不会把
+caller-controlled path 解析进受信集合，因此后续每个 intermediate component 与 executable leaf
+都不得包含任意 symlink。两份 manifest 只有作为本次调用的可丢弃 configure/generate step 的产物
+才会被接受；即便如此，reader 仍会在任何 consumer 启动前完成全部 record、identity、set、
+filename 与 path 校验。有效 consumer 随后按声明顺序运行；某个 consumer 运行失败时，后续
+consumer 不会启动。
 
 当所选 CMake generator 提供多个 configuration 时，smoke 会为 producer 与 consumer 使用同一个
 generator，检查两侧的 `CMAKE_GENERATOR` 和 `CMAKE_CONFIGURATION_TYPES` cache 值，并从
@@ -1192,6 +1198,15 @@ CTest command。这样，无需改写原始 CTest registration，也无需放宽
 removal 失败会原样传播，`lstat` 风格 postcondition 还会确认目录或 dangling link 都没有残留。
 Check/delete 序列不是跨平台原子 filesystem transaction，因此这些 driver 只接受由 caller
 独占、且 component 不会被并发替换的临时 subtree。
+
+同一份受信 root inspector 还服务于两个非破坏性 consumer。
+`DependencyDisabledInstallSmoke` 只有在严格 resolution 等于共享的物理拼写时，才会接受位于任一
+受信 root 下的 generated manifest target；任意 intermediate 或 leaf symlink 仍会因不相等而失败。
+`OpenExrDeepProviderOptionOffSmoke` 在 scrub 工具 evidence 前，只把自身精确 audit root 展开成两种
+受信拼写，从而避免 smoke 自身目录名成为 OpenEXR marker，同时保留真实 dependency 名称供扫描。
+`InstallConsumerArchitecturePropagationSafety` 会注入 synthetic mapping，在不触碰 `/tmp` 的前提下
+跨平台锁定双向拼写、manifest acceptance、root 之后的 symlink 反例、双拼写 evidence scrub，
+以及真实 `-lOpenEXR` rejection。
 
 `OpenCvOperationProviderBuildSmokeSafety` 只针对 disposable temporary root 下的 synthetic
 repository、ancestor 和无关 symlink target，验证这些破坏性 guard、失败传播和 postcondition。

--- a/docs/development/zh/Testing-and-Validation.zh.md
+++ b/docs/development/zh/Testing-and-Validation.zh.md
@@ -1201,6 +1201,11 @@ removal 失败会原样传播，`lstat` 风格 postcondition 还会确认目录�
 Check/delete 序列不是跨平台原子 filesystem transaction，因此这些 driver 只接受由 caller
 独占、且 component 不会被并发替换的临时 subtree。
 
+Live install-consumer CTest inventory validator 只会把同一受信映射应用于 command argv index two
+处的精确 maintained driver。配置的 Python launcher 与 `-B` flag 仍须精确匹配；普通、
+intermediate 或 leaf symlink、parent traversal，以及 driver basename 或 layout drift 都不会进入
+可接受候选集合。
+
 同一份受信 root inspector 还服务于三个非破坏性 consumer。
 `DependencyDisabledInstallSmoke` 只有在严格 resolution 等于共享的物理拼写时，才会接受位于任一
 受信 root 下的 generated manifest target；任意 intermediate 或 leaf symlink 仍会因不相等而失败。

--- a/docs/development/zh/Testing-and-Validation.zh.md
+++ b/docs/development/zh/Testing-and-Validation.zh.md
@@ -233,6 +233,8 @@ symbol 与 dependency。在 marker 分类前，每个精确 audit root 都会通
 必须先以 Photospider 自有诊断失败，不得发现 OpenEXR。
 `OpenExrDeepProviderInstallConsumerSmoke` 是启用态 companion：它安装显式 component，加载真实
 module，解析两个 v3 export，校验 API table，调用 provider destruction，然后卸载 module。
+其生成的 imported-provider path 只有在严格解析后的物理文件仍位于 installed prefix 内、且该
+prefix 之后的每个 component 都不含 symlink 时，才可以使用任一受信 Darwin tmp 拼写。
 
 生成的 clean consumer project 会维护一份有序的 CMake executable target list。同一份 list
 负责创建 target、写出 configure-time 精确 target declaration，并通过 `file(GENERATE)` 提供
@@ -1199,14 +1201,17 @@ removal 失败会原样传播，`lstat` 风格 postcondition 还会确认目录�
 Check/delete 序列不是跨平台原子 filesystem transaction，因此这些 driver 只接受由 caller
 独占、且 component 不会被并发替换的临时 subtree。
 
-同一份受信 root inspector 还服务于两个非破坏性 consumer。
+同一份受信 root inspector 还服务于三个非破坏性 consumer。
 `DependencyDisabledInstallSmoke` 只有在严格 resolution 等于共享的物理拼写时，才会接受位于任一
 受信 root 下的 generated manifest target；任意 intermediate 或 leaf symlink 仍会因不相等而失败。
 `OpenExrDeepProviderOptionOffSmoke` 在 scrub 工具 evidence 前，只把自身精确 audit root 展开成两种
 受信拼写，从而避免 smoke 自身目录名成为 OpenEXR marker，同时保留真实 dependency 名称供扫描。
+它的启用态 companion 只有在 physical-prefix confinement 与 prefix 之后的 component 检查拒绝
+后续每个 symlink 或 escape 后，才会接受使用任一受信拼写的 generated provider target。
 `InstallConsumerArchitecturePropagationSafety` 会注入 synthetic mapping，在不触碰 `/tmp` 的前提下
-跨平台锁定双向拼写、manifest acceptance、root 之后的 symlink 反例、双拼写 evidence scrub，
-以及真实 `-lOpenEXR` rejection。
+跨平台锁定双向拼写、manifest acceptance、root 之后的 symlink 与 escape 反例、双拼写 evidence
+scrub、真实 `-lOpenEXR` rejection、alias 拼写的 `libImath.dylib`/`libOpenEXR.dylib` rejection，
+以及 enabled-provider containment。
 
 `OpenCvOperationProviderBuildSmokeSafety` 只针对 disposable temporary root 下的 synthetic
 repository、ancestor 和无关 symlink target，验证这些破坏性 guard、失败传播和 postcondition。

--- a/tests/integration/cmake_build_smoke_support.py
+++ b/tests/integration/cmake_build_smoke_support.py
@@ -153,6 +153,84 @@ def _rewrite_trusted_system_alias_prefix(
     return rewritten_work
 
 
+def _trusted_system_alias_path_spellings(
+    absolute_path: Path,
+    mapping: tuple[Path, Path] | None,
+) -> tuple[Path, ...]:
+    """@brief Derive exact logical and physical spellings for a trusted path.
+
+    @param absolute_path Absolute lexical path supplied by one smoke boundary.
+    @param mapping Optional already-validated trusted logical/physical root
+      pair. Production obtains it only from ``_trusted_system_tmp_mapping``.
+    @return A stable tuple containing only ``absolute_path`` when it is outside
+      the mapping, otherwise the distinct caller, logical-root, and
+      physical-root spellings for the same lexical suffix.
+    @throws ValueError If ``absolute_path`` is relative or contains parent
+      traversal.
+    @throws RuntimeError If the mapping is invalid or a derived suffix escapes
+      its trusted root.
+    @note This pure helper never resolves ``absolute_path`` and therefore never
+      grants equivalence to an arbitrary intermediate or leaf symlink. Its
+      only equivalence comes from the caller-supplied trusted root pair.
+    """
+
+    if not absolute_path.is_absolute():
+        raise ValueError(
+            f"trusted system temporary path must be absolute: {absolute_path}"
+        )
+    if os.pardir in absolute_path.parts:
+        raise ValueError(
+            "trusted system temporary path contains parent traversal: "
+            f"{absolute_path}"
+        )
+
+    physical_path = _rewrite_trusted_system_alias_prefix(
+        absolute_path, mapping
+    )
+    if mapping is None:
+        return (absolute_path,)
+    logical_root, physical_root = mapping
+    try:
+        relative_path = physical_path.relative_to(physical_root)
+    except ValueError:
+        return (absolute_path,)
+    if os.pardir in relative_path.parts:
+        raise RuntimeError("trusted system temporary mapping escaped its root")
+    logical_path = logical_root / relative_path
+    spellings: list[Path] = []
+    for spelling in (absolute_path, logical_path, physical_path):
+        if spelling not in spellings:
+            spellings.append(spelling)
+    return tuple(spellings)
+
+
+def trusted_system_tmp_path_spellings(
+    absolute_path: Path,
+) -> tuple[Path, ...]:
+    """@brief Return trusted Darwin tmp aliases for one absolute path.
+
+    @param absolute_path Absolute lexical path used by a build-smoke manifest
+      or audit surface.
+    @return The input alone on ordinary platforms or outside the trusted root;
+      for a descendant of Darwin's trusted system tmp mapping, both exact
+      ``/tmp`` and ``/private/tmp`` spellings for the same suffix.
+    @throws OSError If Darwin system roots cannot be inspected or strictly
+      resolved.
+    @throws RuntimeError If canonical root resolution loops, the trusted
+      mapping is invalid, or a derived suffix escapes its root.
+    @throws ValueError If ``absolute_path`` is relative or contains parent
+      traversal.
+    @note Trust discovery is identical to destructive work-tree validation:
+      the function accepts only the root-owned platform alias. It performs no
+      canonical resolution of caller-controlled descendants, so ordinary
+      intermediate and leaf symlinks receive no equivalence.
+    """
+
+    return _trusted_system_alias_path_spellings(
+        absolute_path, _trusted_system_tmp_mapping()
+    )
+
+
 def resolve_work_directory(work: Path, repo: Path) -> Path:
     """@brief Validate a destructive nested-build directory and normalize only
     Darwin's trusted system temporary alias.

--- a/tests/integration/dependency_disabled_install_smoke.py
+++ b/tests/integration/dependency_disabled_install_smoke.py
@@ -14,6 +14,7 @@ from textwrap import dedent
 
 from cmake_build_smoke_support import (
     producer_osx_architecture_arguments,
+    trusted_system_tmp_path_spellings,
 )
 
 
@@ -517,8 +518,10 @@ def configured_consumer_target_files(
     and path. Configured names must remain target-bound native spellings;
     paths must use canonical native spelling, resolve without a symlink inside
     the current consumer build, match the configured name exactly, and
-    identify an executable regular file. Only after the complete inventory
-    passes does the function return any runnable path.
+    identify an executable regular file. Darwin's one trusted logical/physical
+    system-tmp root pair is treated as equivalent without trusting any later
+    symlink. Only after the complete inventory passes does the function return
+    any runnable path.
 
     @param build Configured and built disposable consumer build directory.
     @param configuration Exact configuration selected by the consumer build.
@@ -530,8 +533,9 @@ def configured_consumer_target_files(
       unbuilt/non-file/non-executable target.
     @note The manifests are trusted only as products of this invocation's
       disposable configure/generate step. Exact cross-manifest identity,
-      build-root confinement, basename binding, and file checks prevent either
-      manifest from becoming a general-purpose executable input.
+      build-root confinement, basename binding, shared trusted-root spelling
+      checks, and file checks prevent either manifest from becoming a
+      general-purpose executable input.
     """
 
     build_root = build.resolve(strict=True)
@@ -673,7 +677,16 @@ def configured_consumer_target_files(
                 "dependency-disabled consumer target-file inventory references "
                 f"an unbuilt target {target_name!r}"
             ) from error
-        if executable != resolved_executable:
+        try:
+            trusted_executable_spellings = (
+                trusted_system_tmp_path_spellings(executable)
+            )
+        except (RuntimeError, ValueError) as error:
+            raise RuntimeError(
+                "dependency-disabled consumer target-file inventory contains "
+                f"a noncanonical path for target {target_name!r}"
+            ) from error
+        if resolved_executable not in trusted_executable_spellings:
             raise RuntimeError(
                 "dependency-disabled consumer target-file inventory contains "
                 f"a noncanonical path for target {target_name!r}"

--- a/tests/integration/install_consumer_architecture_propagation_test.py
+++ b/tests/integration/install_consumer_architecture_propagation_test.py
@@ -20,6 +20,7 @@ from unittest import mock
 import cmake_build_smoke_support as architecture_support
 import dependency_disabled_install_smoke as dependency_disabled
 import ipc_disabled_install_smoke as ipc_disabled
+import openexr_deep_provider_option_off_smoke as openexr_option_off
 import static_product_consumer_smoke as static_product
 
 
@@ -760,6 +761,234 @@ class DependencyDisabledResidueClassifierTest(unittest.TestCase):
                 self.assertEqual(
                     dependency_disabled.forbidden_deep_codec_markers(text), []
                 )
+
+
+class TrustedDarwinTemporaryAliasConsumerTest(unittest.TestCase):
+    """@brief Lock trusted Darwin tmp aliases at non-destructive consumers.
+
+    @throws OSError If disposable paths, manifests, or symlinks cannot be
+      created or inspected.
+    @throws AssertionError If trusted logical/physical spellings diverge,
+      arbitrary symlinks gain trust, or evidence scrubbing hides a real
+      optional-dependency marker.
+    @note Every mapping is synthetic and injected into the shared production
+      helper. The tests neither inspect nor replace the host's real ``/tmp``.
+    """
+
+    def test_shared_spellings_are_exact_and_bidirectional(self) -> None:
+        """@brief Map only matching logical and physical tmp descendants.
+
+        @return None after both trusted spellings yield the same two-path set
+          and an unrelated absolute path remains unchanged.
+        @throws AssertionError If spelling equivalence is one-way or widens
+          beyond the injected trusted roots.
+        @note The pure spelling helper receives synthetic absolute paths and
+          proves that user-selected aliases are not inferred from canonical
+          targets.
+        """
+
+        synthetic_root = (
+            pathlib.Path(tempfile.gettempdir()).resolve()
+            / "photospider-trusted-tmp-spelling-fixture"
+        )
+        logical_root = synthetic_root / "logical-tmp"
+        physical_root = synthetic_root / "physical-tmp"
+        logical_child = logical_root / "nested" / "artifact"
+        physical_child = physical_root / "nested" / "artifact"
+        unrelated = pathlib.Path("/synthetic/user-alias/artifact")
+        mapping = (logical_root, physical_root)
+
+        with mock.patch.object(
+            architecture_support,
+            "_trusted_system_tmp_mapping",
+            return_value=None,
+        ):
+            self.assertEqual(
+                architecture_support.trusted_system_tmp_path_spellings(
+                    logical_child
+                ),
+                (logical_child,),
+            )
+
+        with mock.patch.object(
+            architecture_support,
+            "_trusted_system_tmp_mapping",
+            return_value=mapping,
+        ):
+            self.assertEqual(
+                set(
+                    architecture_support.trusted_system_tmp_path_spellings(
+                        logical_child
+                    )
+                ),
+                {logical_child, physical_child},
+            )
+            self.assertEqual(
+                set(
+                    architecture_support.trusted_system_tmp_path_spellings(
+                        physical_child
+                    )
+                ),
+                {logical_child, physical_child},
+            )
+            self.assertEqual(
+                architecture_support.trusted_system_tmp_path_spellings(
+                    unrelated
+                ),
+                (unrelated,),
+            )
+
+    def test_manifest_accepts_trusted_alias_and_rejects_nested_symlink(
+        self,
+    ) -> None:
+        """@brief Accept the system alias but reject a later user symlink.
+
+        @return None after logical and physical manifest spellings bind to the
+          same executable while a symlinked configuration directory fails.
+        @throws OSError If fixture creation or executable inspection fails.
+        @throws AssertionError If the trusted root is rejected or a nested
+          arbitrary symlink reaches consumer execution.
+        @note The injected mapping models only Darwin's platform-owned alias;
+          both symlinks and every target live below a disposable sandbox.
+        """
+
+        with tempfile.TemporaryDirectory(
+            prefix="photospider-consumer-target-trusted-tmp-alias-"
+        ) as temporary:
+            sandbox = pathlib.Path(temporary).resolve()
+            logical_root = sandbox / "logical-tmp"
+            physical_root = sandbox / "physical-tmp"
+            physical_root.mkdir()
+            try:
+                logical_root.symlink_to(
+                    physical_root, target_is_directory=True
+                )
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"directory symlinks unavailable: {error}")
+            mapping = (logical_root, physical_root)
+            configuration = "RelWithDebInfo"
+            target_name = "consumer_safe"
+            build = physical_root / "consumer-build"
+            executable_by_target = write_consumer_target_inventory_fixture(
+                build,
+                configuration,
+                (target_name,),
+            )
+            physical_executable = executable_by_target[target_name]
+            logical_executable = logical_root / build.name / target_name
+            manifest = dependency_disabled.consumer_target_file_manifest_path(
+                build, configuration
+            )
+
+            def write_target_path(path: pathlib.Path) -> None:
+                """@brief Replace the test-owned target-file manifest path.
+
+                @param path Absolute executable spelling for this assertion.
+                @return None after serializing one valid target-file record.
+                @throws OSError If the disposable manifest cannot be written.
+                @note Target name and configured filename remain unchanged so
+                  only path equivalence varies between assertions.
+                """
+
+                write_exact_text(
+                    manifest,
+                    (
+                        dependency_disabled.CONSUMER_TARGET_FILE_MANIFEST_HEADER
+                        + "\n"
+                        + f"{target_name}\t{target_name}\t{path}\n"
+                    ),
+                )
+
+            with mock.patch.object(
+                architecture_support,
+                "_trusted_system_tmp_mapping",
+                return_value=mapping,
+            ):
+                for executable_spelling in (
+                    logical_executable,
+                    physical_executable,
+                ):
+                    with self.subTest(spelling=executable_spelling):
+                        write_target_path(executable_spelling)
+                        self.assertEqual(
+                            dependency_disabled.configured_consumer_target_files(
+                                build, configuration
+                            ),
+                            [(target_name, physical_executable)],
+                        )
+
+                real_configuration = build / "real-configuration"
+                real_configuration.mkdir()
+                relocated_executable = real_configuration / target_name
+                physical_executable.replace(relocated_executable)
+                configured_alias = build / configuration
+                configured_alias.symlink_to(
+                    real_configuration, target_is_directory=True
+                )
+                write_target_path(
+                    logical_root
+                    / build.name
+                    / configuration
+                    / target_name
+                )
+                with self.assertRaisesRegex(
+                    RuntimeError, "noncanonical path"
+                ):
+                    dependency_disabled.configured_consumer_target_files(
+                        build, configuration
+                    )
+
+    def test_command_scrub_covers_aliases_but_preserves_real_markers(
+        self,
+    ) -> None:
+        """@brief Scrub trusted root names without hiding dependency leakage.
+
+        @return None after logical and physical work prefixes disappear while
+          a real OpenEXR library marker remains rejected.
+        @throws AssertionError If a trusted spelling survives or the marker
+          classifier is weakened.
+        @throws Nothing; the expected real-leak RuntimeError is asserted
+          locally.
+        @note The work basename intentionally contains both forbidden marker
+          spellings that caused the Darwin build-smoke false positive.
+        """
+
+        synthetic_root = (
+            pathlib.Path(tempfile.gettempdir()).resolve()
+            / "photospider-trusted-tmp-scrub-fixture"
+        )
+        logical_root = synthetic_root / "logical-tmp"
+        physical_root = synthetic_root / "physical-tmp"
+        work_name = "openexr_deep_provider_option_off_smoke"
+        logical_work = logical_root / work_name
+        physical_work = physical_root / work_name
+        command_surface = (
+            f"cc -c {logical_work}/consumer/main.c\n"
+            f"cmake -E chdir {physical_work}/consumer-build"
+        )
+        mapping = (logical_root, physical_root)
+
+        with mock.patch.object(
+            architecture_support,
+            "_trusted_system_tmp_mapping",
+            return_value=mapping,
+        ):
+            scrubbed = openexr_option_off.scrub_paths(
+                command_surface, [physical_work]
+            )
+            self.assertNotIn("openexr", scrubbed.lower())
+            openexr_option_off.reject_forbidden_surface(
+                scrubbed, "trusted alias command evidence"
+            )
+            leaked_surface = openexr_option_off.scrub_paths(
+                command_surface + "\n-lOpenEXR",
+                [physical_work],
+            )
+
+        with self.assertRaisesRegex(RuntimeError, "openexr"):
+            openexr_option_off.reject_forbidden_surface(
+                leaked_surface, "real dependency evidence"
+            )
 
 
 class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):

--- a/tests/integration/install_consumer_architecture_propagation_test.py
+++ b/tests/integration/install_consumer_architecture_propagation_test.py
@@ -143,6 +143,24 @@ INSTALL_CONSUMER_CTEST_NAMES = tuple(
 )
 
 
+def darwin_architecture_arguments_for_test(
+    build: pathlib.Path,
+) -> tuple[str, ...]:
+    """@brief Derive producer architecture argv through a Darwin-only seam.
+
+    @param build Synthetic configured producer whose cache owns the value.
+    @return Exact production helper result for a Darwin child configure.
+    @throws OSError If an existing producer cache cannot be read.
+    @note Passing the platform directly to the architecture helper leaves
+      ``platform.system()`` host-native for trusted temporary-path discovery,
+      so a non-Darwin runner never inspects Darwin's ``/private/tmp`` root.
+    """
+
+    return architecture_support.producer_osx_architecture_arguments(
+        build, system_name="Darwin"
+    )
+
+
 def ctest_test_entry(
     name: str,
     command: list[str] | None,
@@ -1194,8 +1212,9 @@ class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):
         @throws RuntimeError If producer or consumer inventory validation fails.
         @throws subprocess.CalledProcessError If the recorder injects a build or
           consumer execution failure.
-        @note Darwin is selected so the same invocation also retains the six
-          child-configure architecture propagation boundary.
+        @note Darwin is injected only at the producer-architecture helper, so
+          the same invocation retains the six child-configure propagation
+          boundary without changing host temporary-path discovery.
         """
 
         repo = sandbox / "repo"
@@ -1243,7 +1262,11 @@ class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):
                 "validate_no_optional_deep_codec_residue",
                 return_value=None,
             ),
-            mock.patch("platform.system", return_value="Darwin"),
+            mock.patch.object(
+                dependency_disabled,
+                "producer_osx_architecture_arguments",
+                side_effect=darwin_architecture_arguments_for_test,
+            ),
         ):
             return dependency_disabled.main()
 
@@ -3448,6 +3471,8 @@ class InstallConsumerArchitecturePropagationTest(unittest.TestCase):
           architecture argument.
         @note The test exercises the real reusable-producer validator and
           ``main`` command construction while replacing subprocess execution.
+          Darwin is injected only at the producer-architecture helper, leaving
+          trusted temporary-path discovery scoped to the actual host.
         """
 
         with tempfile.TemporaryDirectory(
@@ -3507,8 +3532,10 @@ class InstallConsumerArchitecturePropagationTest(unittest.TestCase):
                     "validate_no_optional_deep_codec_residue",
                     return_value=None,
                 ),
-                mock.patch(
-                    "platform.system", return_value="Darwin"
+                mock.patch.object(
+                    dependency_disabled,
+                    "producer_osx_architecture_arguments",
+                    side_effect=darwin_architecture_arguments_for_test,
                 ),
             ):
                 self.assertEqual(dependency_disabled.main(), 0)

--- a/tests/integration/install_consumer_architecture_propagation_test.py
+++ b/tests/integration/install_consumer_architecture_propagation_test.py
@@ -273,7 +273,8 @@ def require_install_consumer_ctest_commands(
     name zero times. It then reuses the production build-smoke selector to
     reject missing labels, disabled state, and unusable commands. Each
     surviving argv must start with the configured Python launcher, immediately
-    followed by ``-B`` and the exact maintained driver.
+    followed by ``-B`` and the exact maintained driver. Only the driver path
+    may use either spelling of Darwin's verified system tmp-root alias.
 
     @param inventory Parsed production ``Inventory`` instance to validate.
     @param python_executable Exact CMake-selected Python launcher.
@@ -285,8 +286,16 @@ def require_install_consumer_ctest_commands(
       configuration-inactive maintained name is present; or an expected entry
       lacks the label, is disabled/commandless, or has a different command
       prefix.
+    @throws OSError If Darwin's trusted system roots cannot be inspected or
+      strictly resolved.
+    @throws RuntimeError If strict root resolution loops or the trusted mapping
+      cannot preserve the exact driver suffix inside both roots.
+    @throws ValueError If an internal expected driver path is relative or
+      contains parent traversal.
     @note The function inspects only immutable in-memory inventory. It neither
-      launches CTest nor executes any smoke command.
+      launches CTest nor executes any smoke command. Alias equivalence applies
+      only to argv index two; the launcher, ``-B``, basename, and repository
+      layout remain exact.
     """
 
     expected_install_consumer_ctest_entries(
@@ -314,20 +323,29 @@ def require_install_consumer_ctest_commands(
         if expected_count == 0:
             continue
         record = inventory.require_selected(test_name)
-        expected_prefix = (
-            python_executable,
-            "-B",
-            str(integration_directory / driver_name),
+        expected_driver_spellings = (
+            architecture_support.trusted_system_tmp_path_spellings(
+                integration_directory / driver_name
+            )
         )
-        if record.command is None or record.command[:3] != expected_prefix:
+        expected_prefixes = tuple(
+            (python_executable, "-B", str(driver_spelling))
+            for driver_spelling in expected_driver_spellings
+        )
+        if (
+            record.command is None
+            or record.command[:3] not in expected_prefixes
+        ):
             observed_prefix = (
                 None
                 if record.command is None
                 else list(record.command[:3])
             )
             raise ctest_inventory.InventoryError(
-                f"Install-consumer smoke {test_name!r} must start with "
-                f"{list(expected_prefix)!r}; observed {observed_prefix!r}."
+                f"Install-consumer smoke {test_name!r} must start with one "
+                "of "
+                f"{[list(prefix) for prefix in expected_prefixes]!r}; "
+                f"observed {observed_prefix!r}."
             )
 
 
@@ -2586,6 +2604,157 @@ class InstallConsumerCTestRegistrationTest(unittest.TestCase):
                 python_executable=python_executable,
                 expected_test_names=INSTALL_CONSUMER_CTEST_NAMES[:2],
             )
+
+    def test_trusted_darwin_driver_spellings_are_accepted(self) -> None:
+        """@brief Accept both trusted spellings of each exact driver path.
+
+        @return None after logical and physical Darwin tmp-root spellings pass
+          without changing the launcher, flag, driver basename, or layout.
+        @throws AssertionError If either trusted spelling is rejected.
+        @note A synthetic mapping exercises the production spelling helper on
+          every platform without inspecting or replacing the host's ``/tmp``.
+        """
+
+        with tempfile.TemporaryDirectory(
+            prefix="photospider-ctest-command-trusted-tmp-alias-"
+        ) as temporary:
+            sandbox = pathlib.Path(temporary).resolve()
+            logical_root = sandbox / "logical-tmp"
+            physical_root = sandbox / "physical-tmp"
+            repository = physical_root / "repo"
+            mapping = (logical_root, physical_root)
+            python_executable = "/fixture/python3"
+            driver_by_name = dict(INSTALL_CONSUMER_CTEST_REGISTRATIONS)
+
+            with (
+                mock.patch.object(
+                    sys.modules[__name__],
+                    "REPOSITORY_ROOT",
+                    repository,
+                ),
+                mock.patch.object(
+                    architecture_support,
+                    "_trusted_system_tmp_mapping",
+                    return_value=mapping,
+                ),
+            ):
+                for spelling_root in (logical_root, physical_root):
+                    with self.subTest(spelling_root=spelling_root):
+                        entries = expected_install_consumer_ctest_entries(
+                            python_executable
+                        )
+                        for entry in entries:
+                            command = list(entry["command"])
+                            command[2] = str(
+                                spelling_root
+                                / "repo"
+                                / "tests"
+                                / "integration"
+                                / driver_by_name[str(entry["name"])]
+                            )
+                            entry["command"] = command
+                        inventory = ctest_inventory.parse_inventory(
+                            ctest_inventory_payload(entries)
+                        )
+                        require_install_consumer_ctest_commands(
+                            inventory,
+                            python_executable=python_executable,
+                        )
+
+    def test_untrusted_driver_aliases_and_path_drift_fail_closed(
+        self,
+    ) -> None:
+        """@brief Reject non-system aliases and lexical driver-path drift.
+
+        @return None after ordinary-root, intermediate, and leaf symlinks,
+          parent traversal, basename drift, and layout drift all fail.
+        @throws OSError If disposable files or symlinks cannot be created.
+        @throws AssertionError If any path outside the exact trusted root
+          spelling pair is accepted as a maintained driver.
+        @note Each symlink resolves to the expected disposable driver, proving
+          that canonical equality alone never widens the command contract.
+        """
+
+        with tempfile.TemporaryDirectory(
+            prefix="photospider-ctest-command-untrusted-alias-"
+        ) as temporary:
+            sandbox = pathlib.Path(temporary).resolve()
+            logical_root = sandbox / "logical-tmp"
+            physical_root = sandbox / "physical-tmp"
+            ordinary_root_alias = sandbox / "ordinary-tmp-alias"
+            repository = physical_root / "repo"
+            integration_directory = repository / "tests" / "integration"
+            integration_directory.mkdir(parents=True)
+            driver_name = INSTALL_CONSUMER_CTEST_REGISTRATIONS[0][1]
+            expected_driver = integration_directory / driver_name
+            write_exact_text(expected_driver, "# driver fixture\n")
+            intermediate_alias = repository / "tests" / "integration-alias"
+            leaf_alias = integration_directory / "driver-leaf-alias.py"
+            try:
+                logical_root.symlink_to(
+                    physical_root, target_is_directory=True
+                )
+                ordinary_root_alias.symlink_to(
+                    physical_root, target_is_directory=True
+                )
+                intermediate_alias.symlink_to(
+                    integration_directory, target_is_directory=True
+                )
+                leaf_alias.symlink_to(expected_driver)
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"symlinks unavailable: {error}")
+
+            mapping = (logical_root, physical_root)
+            invalid_paths = (
+                ordinary_root_alias
+                / "repo"
+                / "tests"
+                / "integration"
+                / driver_name,
+                intermediate_alias / driver_name,
+                leaf_alias,
+                logical_root
+                / os.pardir
+                / physical_root.name
+                / "repo"
+                / "tests"
+                / "integration"
+                / driver_name,
+                integration_directory / "not_the_install_driver.py",
+                repository / "tests" / "wrong-layout" / driver_name,
+            )
+            python_executable = "/fixture/python3"
+            with (
+                mock.patch.object(
+                    sys.modules[__name__],
+                    "REPOSITORY_ROOT",
+                    repository,
+                ),
+                mock.patch.object(
+                    architecture_support,
+                    "_trusted_system_tmp_mapping",
+                    return_value=mapping,
+                ),
+            ):
+                for invalid_path in invalid_paths:
+                    with self.subTest(invalid_path=invalid_path):
+                        entries = expected_install_consumer_ctest_entries(
+                            python_executable
+                        )
+                        command = list(entries[0]["command"])
+                        command[2] = str(invalid_path)
+                        entries[0]["command"] = command
+                        inventory = ctest_inventory.parse_inventory(
+                            ctest_inventory_payload(entries)
+                        )
+                        with self.assertRaisesRegex(
+                            ctest_inventory.InventoryError,
+                            "must start with",
+                        ):
+                            require_install_consumer_ctest_commands(
+                                inventory,
+                                python_executable=python_executable,
+                            )
 
     def test_missing_inactive_and_commented_entries_fail_closed(
         self,

--- a/tests/integration/install_consumer_architecture_propagation_test.py
+++ b/tests/integration/install_consumer_architecture_propagation_test.py
@@ -990,6 +990,177 @@ class TrustedDarwinTemporaryAliasConsumerTest(unittest.TestCase):
                 leaked_surface, "real dependency evidence"
             )
 
+    def test_native_audit_preserves_alias_spelled_library_markers(
+        self,
+    ) -> None:
+        """@brief Preserve library basenames across trusted-alias scrubbing.
+
+        @return None after logical and physical spellings of ``libImath`` and
+          ``libOpenEXR`` remain rejectable on symbol and dependency surfaces.
+        @throws AssertionError If native artifact auditing hides a qualified
+          library marker by scrubbing the artifact leaf as an audit root.
+        @throws Nothing; each expected native-leak RuntimeError is asserted
+          locally while inspector execution is replaced by bounded fixtures.
+        @note The physical artifact path models the file supplied to the native
+          inspector, while its evidence deliberately alternates both trusted
+          Darwin spellings without inspecting the host's real ``/tmp``.
+        """
+
+        synthetic_root = (
+            pathlib.Path(tempfile.gettempdir()).resolve()
+            / "photospider-trusted-tmp-native-audit-fixture"
+        )
+        logical_root = synthetic_root / "logical-tmp"
+        physical_root = synthetic_root / "physical-tmp"
+        work_name = "openexr_deep_provider_option_off_smoke"
+        logical_work = logical_root / work_name
+        physical_work = physical_root / work_name
+        mapping = (logical_root, physical_root)
+
+        with mock.patch.object(
+            architecture_support,
+            "_trusted_system_tmp_mapping",
+            return_value=mapping,
+        ):
+            for library_name, expected_marker in (
+                ("libImath.dylib", "libimath"),
+                ("libOpenEXR.dylib", "openexr"),
+            ):
+                artifact = physical_work / library_name
+                for evidence_root in (logical_work, physical_work):
+                    evidence_path = str(evidence_root / library_name)
+                    for surface_kind in ("symbols", "dependencies"):
+                        symbol_surface = (
+                            evidence_path
+                            if surface_kind == "symbols"
+                            else "_photospider_neutral_symbol"
+                        )
+                        dependency_surface = (
+                            evidence_path
+                            if surface_kind == "dependencies"
+                            else "/usr/lib/libSystem.B.dylib"
+                        )
+                        with self.subTest(
+                            library=library_name,
+                            spelling=evidence_root,
+                            surface=surface_kind,
+                        ), mock.patch.object(
+                            openexr_option_off,
+                            "symbol_surfaces",
+                            return_value=(symbol_surface, ""),
+                        ), mock.patch.object(
+                            openexr_option_off,
+                            "dependency_surface",
+                            return_value=dependency_surface,
+                        ):
+                            with self.assertRaisesRegex(
+                                RuntimeError, expected_marker
+                            ):
+                                openexr_option_off.validate_native_artifacts(
+                                    [artifact],
+                                    pathlib.Path("/synthetic/nm"),
+                                    "nm",
+                                    [physical_work],
+                                    "trusted-alias-native-audit",
+                                )
+
+    def test_enabled_provider_accepts_aliases_and_rejects_symlink_escape(
+        self,
+    ) -> None:
+        """@brief Confine the enabled provider across trusted tmp spellings.
+
+        @return None after logical/physical manifest spellings resolve to the
+          same physical provider while leaf, intermediate, and ``..`` escapes
+          are rejected.
+        @throws OSError If disposable directories, files, or symlinks cannot be
+          created or inspected.
+        @throws AssertionError If a trusted spelling is rejected or an
+          untrusted post-root path reaches the enabled consumer.
+        @note The synthetic logical root is the only trusted symlink. Every
+          later symlink and all files remain inside the disposable sandbox.
+        """
+
+        with tempfile.TemporaryDirectory(
+            prefix="photospider-enabled-provider-trusted-tmp-alias-"
+        ) as temporary:
+            sandbox = pathlib.Path(temporary).resolve()
+            logical_root = sandbox / "logical-tmp"
+            physical_root = sandbox / "physical-tmp"
+            physical_root.mkdir()
+            try:
+                logical_root.symlink_to(
+                    physical_root, target_is_directory=True
+                )
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"directory symlinks unavailable: {error}")
+
+            mapping = (logical_root, physical_root)
+            work_name = "openexr_deep_provider_install_consumer_smoke"
+            provider_relative = (
+                pathlib.Path("lib")
+                / "photospider"
+                / "providers"
+                / "libphotospider_openexr_deep_provider.so"
+            )
+            physical_prefix = physical_root / work_name / "prefix"
+            physical_provider = physical_prefix / provider_relative
+            physical_provider.parent.mkdir(parents=True)
+            write_exact_text(physical_provider, "provider fixture\n")
+            logical_provider = (
+                logical_root / work_name / "prefix" / provider_relative
+            )
+
+            outside_directory = physical_root / work_name / "outside"
+            outside_directory.mkdir()
+            outside_provider = outside_directory / physical_provider.name
+            write_exact_text(outside_provider, "outside provider fixture\n")
+            leaf_symlink = physical_prefix / "provider-link.so"
+            nested_symlink = physical_prefix / "linked-provider-directory"
+            try:
+                leaf_symlink.symlink_to(physical_provider)
+                nested_symlink.symlink_to(
+                    outside_directory, target_is_directory=True
+                )
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"provider symlinks unavailable: {error}")
+
+            escaped_provider = (
+                physical_prefix
+                / ".."
+                / outside_directory.name
+                / outside_provider.name
+            )
+            invalid_paths = (
+                leaf_symlink,
+                nested_symlink / outside_provider.name,
+                escaped_provider,
+            )
+
+            with mock.patch.object(
+                architecture_support,
+                "_trusted_system_tmp_mapping",
+                return_value=mapping,
+            ):
+                for provider_spelling in (
+                    logical_provider,
+                    physical_provider,
+                ):
+                    with self.subTest(spelling=provider_spelling):
+                        self.assertEqual(
+                            openexr_option_off.validate_enabled_provider_path(
+                                provider_spelling, physical_prefix
+                            ),
+                            physical_provider,
+                        )
+                for invalid_path in invalid_paths:
+                    with self.subTest(invalid=invalid_path):
+                        with self.assertRaisesRegex(
+                            RuntimeError, "escaped its prefix"
+                        ):
+                            openexr_option_off.validate_enabled_provider_path(
+                                invalid_path, physical_prefix
+                            )
+
 
 class DependencyDisabledConsumerTargetInventoryTest(unittest.TestCase):
     """@brief Validate dynamic consumer discovery and fail-closed execution.

--- a/tests/integration/openexr_deep_provider_option_off_smoke.py
+++ b/tests/integration/openexr_deep_provider_option_off_smoke.py
@@ -14,6 +14,7 @@ from textwrap import dedent
 from cmake_build_smoke_support import (
     producer_osx_architecture_arguments,
     remove_work_tree,
+    trusted_system_tmp_path_spellings,
 )
 
 
@@ -419,12 +420,25 @@ def scrub_paths(surface: str, roots: list[Path]) -> str:
     @param surface Complete command/dependency/symbol output.
     @param roots Exact work/build/install paths whose names are non-semantic.
     @return Text with each exact native/POSIX path replaced by an audit token.
-    @throws Nothing under string replacement.
-    @note Header/library names below those roots remain visible and scannable.
+    @throws OSError If trusted Darwin system roots cannot be inspected or
+      strictly resolved.
+    @throws RuntimeError If trusted root resolution or mapping is invalid.
+    @throws ValueError If a supplied root is relative or contains parent
+      traversal.
+    @note Both spellings of Darwin's trusted ``/tmp``/``/private/tmp`` root are
+      scrubbed. No caller-controlled symlink is resolved; header/library names
+      below those exact roots remain visible and scannable.
     """
 
     scrubbed = surface
-    for root in sorted(set(roots), key=lambda item: len(str(item)), reverse=True):
+    root_spellings = {
+        spelling
+        for root in roots
+        for spelling in trusted_system_tmp_path_spellings(root)
+    }
+    for root in sorted(
+        root_spellings, key=lambda item: len(str(item)), reverse=True
+    ):
         scrubbed = scrubbed.replace(str(root), "<audit-root>")
         scrubbed = scrubbed.replace(root.as_posix(), "<audit-root>")
     return scrubbed

--- a/tests/integration/openexr_deep_provider_option_off_smoke.py
+++ b/tests/integration/openexr_deep_provider_option_off_smoke.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import re
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -414,27 +415,30 @@ def dynamic_artifact(path: Path) -> bool:
     return path.suffix.lower() in {".dylib", ".so", ".dll", ".exe"} or ".so." in name
 
 
-def scrub_paths(surface: str, roots: list[Path]) -> str:
+def scrub_paths(surface: str, directory_roots: list[Path]) -> str:
     """@brief Remove only known workspace prefixes from auditable tool text.
 
     @param surface Complete command/dependency/symbol output.
-    @param roots Exact work/build/install paths whose names are non-semantic.
-    @return Text with each exact native/POSIX path replaced by an audit token.
+    @param directory_roots Exact work/build/install directory prefixes whose
+      names are non-semantic.
+    @return Text with each exact native/POSIX directory prefix replaced by an
+      audit token while descendant basenames remain visible.
     @throws OSError If trusted Darwin system roots cannot be inspected or
       strictly resolved.
     @throws RuntimeError If trusted root resolution or mapping is invalid.
-    @throws ValueError If a supplied root is relative or contains parent
-      traversal.
+    @throws ValueError If a supplied directory root is relative or contains
+      parent traversal.
     @note Both spellings of Darwin's trusted ``/tmp``/``/private/tmp`` root are
-      scrubbed. No caller-controlled symlink is resolved; header/library names
-      below those exact roots remain visible and scannable.
+      scrubbed. No caller-controlled symlink is resolved. Leaf artifact and
+      evidence-file paths must not be supplied as roots, so header/library
+      names below the directory prefixes remain visible and scannable.
     """
 
     scrubbed = surface
     root_spellings = {
         spelling
-        for root in roots
-        for spelling in trusted_system_tmp_path_spellings(root)
+        for directory_root in directory_roots
+        for spelling in trusted_system_tmp_path_spellings(directory_root)
     }
     for root in sorted(
         root_spellings, key=lambda item: len(str(item)), reverse=True
@@ -471,18 +475,20 @@ def validate_native_artifacts(
     @param artifacts Exact runtime/static/product/install artifact inventory.
     @param tool Resolved actual symbol inspector.
     @param tool_kind nm or dumpbin selection.
-    @param roots Known prefixes scrubbed before marker scans.
+    @param roots Known directory prefixes scrubbed before marker scans.
     @param category Stable evidence label printed into CTest output.
     @return None after every artifact passes.
     @throws OSError If an inspector cannot start.
     @throws RuntimeError For empty inventory, rejected tools, or codec residue.
+    @note Artifact leaf paths are deliberately excluded from scrub roots so
+      their basenames remain part of the audited symbol/dependency evidence.
     """
 
     if not artifacts:
         raise RuntimeError(f"{category} native artifact inventory is empty")
     for artifact in artifacts:
         defined, undefined = symbol_surfaces(tool, tool_kind, artifact)
-        symbol_text = scrub_paths(defined + "\n" + undefined, roots + [artifact])
+        symbol_text = scrub_paths(defined + "\n" + undefined, roots)
         reject_forbidden_surface(symbol_text, f"{category} symbols for {artifact.name}")
         defined_count = len([line for line in defined.splitlines() if line.strip()])
         undefined_count = len(
@@ -493,9 +499,7 @@ def validate_native_artifacts(
             f"defined={defined_count} undefined={undefined_count}"
         )
         if dynamic_artifact(artifact):
-            dependencies = scrub_paths(
-                dependency_surface(artifact), roots + [artifact]
-            )
+            dependencies = scrub_paths(dependency_surface(artifact), roots)
             reject_forbidden_surface(
                 dependencies, f"{category} dependencies for {artifact.name}"
             )
@@ -795,10 +799,13 @@ def validate_neutral_target_surface(
 
     @param build Configured and built neutral external-consumer directory.
     @param config Active single- or multi-config name.
-    @param roots Exact work/build/install prefixes whose names are non-semantic.
+    @param roots Exact work/build/install directory prefixes whose names are
+      non-semantic.
     @return None after one generated target surface passes.
     @throws OSError If generated evidence cannot be read.
     @throws RuntimeError If evidence is missing or contains codec residue.
+    @note The generated evidence-file basename remains visible to the scan;
+      only its containing audit directories may be scrubbed.
     """
 
     preferred = build / f"neutral-target-{config}.txt"
@@ -813,7 +820,7 @@ def validate_neutral_target_surface(
     if not surface.strip():
         raise RuntimeError("neutral imported-target surface is empty")
     reject_forbidden_surface(
-        scrub_paths(surface, roots + candidates),
+        scrub_paths(surface, roots),
         "neutral imported-target interfaces",
     )
     print(f"TARGET-AUDIT {candidates[0].name}: PASS")
@@ -924,6 +931,70 @@ def find_consumer_executable(build: Path, enabled: bool) -> Path:
     if len(candidates) != 1:
         raise RuntimeError(f"expected one consumer executable, found {candidates}")
     return candidates[0]
+
+
+def validate_enabled_provider_path(provider: Path, prefix: Path) -> Path:
+    """@brief Validate one enabled provider manifest path below its install.
+
+    @param provider Absolute imported-target path read from the generated
+      enabled-consumer manifest.
+    @param prefix Physical installed-package prefix owned by this smoke run.
+    @return Strictly resolved physical provider path below ``prefix``.
+    @throws RuntimeError If metadata cannot be read, the provider is absent or
+      outside the prefix, or any untrusted intermediate/leaf symlink follows
+      the trusted system tmp root.
+    @note Only the shared root-owned Darwin ``/tmp``/``/private/tmp`` mapping
+      may change the manifest spelling. No caller-controlled path is resolved
+      into the trusted set. The test-owned prefix is not concurrently mutated
+      while the component and strict-resolution checks run.
+    """
+
+    diagnostic = "enabled imported provider target escaped its prefix"
+    try:
+        prefix_root = prefix.resolve(strict=True)
+        provider_spellings = trusted_system_tmp_path_spellings(provider)
+    except (OSError, RuntimeError, ValueError) as error:
+        raise RuntimeError(diagnostic) from error
+    if not prefix_root.is_dir():
+        raise RuntimeError(diagnostic)
+
+    physical_candidates: list[Path] = []
+    for spelling in provider_spellings:
+        if (
+            prefix_root in spelling.parents
+            and spelling not in physical_candidates
+        ):
+            physical_candidates.append(spelling)
+    if len(physical_candidates) != 1:
+        raise RuntimeError(diagnostic)
+    physical_provider = physical_candidates[0]
+
+    try:
+        relative_provider = physical_provider.relative_to(prefix_root)
+    except ValueError as error:
+        raise RuntimeError(diagnostic) from error
+    if not relative_provider.parts or ".." in relative_provider.parts:
+        raise RuntimeError(diagnostic)
+
+    inspected = prefix_root
+    try:
+        for component in relative_provider.parts:
+            inspected /= component
+            if stat.S_ISLNK(inspected.lstat().st_mode):
+                raise RuntimeError(diagnostic)
+        resolved_provider = physical_provider.resolve(strict=True)
+    except OSError as error:
+        raise RuntimeError(diagnostic) from error
+    try:
+        resolved_provider.relative_to(prefix_root)
+    except ValueError as error:
+        raise RuntimeError(diagnostic) from error
+    if (
+        resolved_provider != physical_provider
+        or not resolved_provider.is_file()
+    ):
+        raise RuntimeError(diagnostic)
+    return resolved_provider
 
 
 def main() -> int:
@@ -1119,9 +1190,9 @@ def main() -> int:
         executable = find_consumer_executable(consumer_build, enabled)
         if enabled:
             manifest = consumer_build / f"provider-{args.config}.txt"
-            provider = Path(manifest.read_text(encoding="utf-8"))
-            if not provider.is_file() or prefix not in provider.parents:
-                raise RuntimeError("enabled imported provider target escaped its prefix")
+            provider = validate_enabled_provider_path(
+                Path(manifest.read_text(encoding="utf-8")), prefix
+            )
             run([str(executable), str(provider)], work)
         else:
             command_evidence = collect_consumer_command_evidence(
@@ -1147,12 +1218,12 @@ def main() -> int:
                 [executable],
                 symbol_tool,
                 symbol_kind,
-                [work, build, prefix, consumer_build, executable],
+                consumer_audit_roots,
                 "OFF-neutral-consumer",
             )
             executable_dependencies = scrub_paths(
                 dependency_surface(executable),
-                [work, build, prefix, consumer_build, executable],
+                consumer_audit_roots,
             )
             reject_forbidden_surface(
                 executable_dependencies, "neutral consumer dependencies"


### PR DESCRIPTION
## Summary

- treat only the validated root-owned Darwin `/tmp` and `/private/tmp` roots as equivalent in build-smoke manifests and exact maintained CTest driver paths
- scrub both trusted directory-prefix spellings before OpenEXR marker classification while preserving artifact/header/library basenames
- validate enabled-provider aliases with strict physical-prefix containment and post-prefix symlink rejection
- isolate Darwin architecture mocks from host temporary-root discovery
- add cross-platform regressions for trusted spellings, ordinary symlink/escape rejection, real marker preservation, and exact CTest command drift
- synchronize the English validation contract and Chinese mirror

## Validation

- exact-head local healthcheck: 18/18, 15/15, 9/9, 32/32
- InstallConsumerArchitecturePropagationSafety CTest: 1/1 passed
- install-consumer architecture module: 45/45 passed, with 1 expected direct-run live-metadata skip
- command-drift regressions: 3/3 passed
- WorkDirectorySafetyTest: 12/12 passed
- DependencyDisabledInstallSmoke: passed
- OpenExrDeepProviderOptionOffSmoke: passed, including V-14 17/17
- OpenExrDeepProviderInstallConsumerSmoke: passed through build/install/load/destroy/unload
- fresh independent rereview of exact head: P0/P1/P2/P3 all 0

## Review closure

- Codex P1 about process-wide Darwin mocks was reproduced as 4 errors on a Linux-shaped host and fixed by injecting Darwin only at the architecture helper seam
- local CTest exposed `/tmp` versus `/private/tmp` driver argv drift; the validator now accepts only the verified root spelling pair and still rejects ordinary root/intermediate/leaf aliases, parent traversal, basename drift, and layout drift

## Scope

This PR is based directly on `main` and contains no execution-profile/server-isolation refactor changes. It does not change workflows, CMake/CTest inventory, product APIs, or runtime behavior.